### PR TITLE
bSF and others

### DIFF
--- a/nanoaodframe/print_syst_table.py
+++ b/nanoaodframe/print_syst_table.py
@@ -4,14 +4,14 @@ from collections import OrderedDict
 
 from optparse import OptionParser
 parser = OptionParser(usage="%prog [options]")
-parser.add_option("-O", "--output",  dest="output", type="string", default="", help="Output folder name")
+parser.add_option("-I", "--input",  dest="input", type="string", default="", help="Input folder name")
 parser.add_option("-Y", "--year",  dest="year", type="string", default="", help="Select 2016pre/post, 2017, or 2018 for years")
 (options, args) = parser.parse_args()
 
 year = options.year
 
 config_path = '../plotIt/configs/'
-dest_path = os.path.join('./', options.output)
+dest_path = os.path.join('./', options.input)
 tmp_file_name = 'temp_' + year + '_forSyst.yml'
 string_to_add = 'systematics:\n'
 plot_to_add = "plots:\n  include: ['histos_yield.yml']\n\n"

--- a/nanoaodframe/print_syst_table.py
+++ b/nanoaodframe/print_syst_table.py
@@ -117,13 +117,13 @@ for key, value in unc_cat.items():
     #Remove signals in TT specific sources
     with open(os.path.join(dest_path, 'figure_' + year, 'systematics.tex'), 'r') as f:
         with open(os.path.join(dest_path, 'figure_' + year, 'systematics_' + syst_postfix + '.tex'), 'w+') as f1:
-            isTT = False
-            if any(x in key for x in ['scale', 'ps', 'hdamp', 'py8tune', 'pdf', 'xsec']): isTT = True
-            #if any(x in key for x in ['hdamp', 'py8tune', 'xsec']): isTT = True
+            isTTsyst = False
+            if key in ['scale', 'ps', 'hdamp', 'py8tune', 'pdf']: isTTsyst = True
             for line in f:
-                if isTT and 'ttbar' in line: isTT = False
-                if isTT: continue
-                if any(x in line[0] for x in ['LFV','LL','LJ','Had']): line = line[1:]
+                isTT = False
+                if 'ttbar' in line or 'LFV' in line: isTT = True
+                if not isTT and isTTsyst and 'hline' not in line and 'Total' not in line: continue
+                if any(str(x) in line[0] for x in list(range(1,10))): line = line[1:]
                 f1.write(line)
 
     string_to_add = 'systematics:\n'
@@ -143,7 +143,8 @@ with open("total_syst_template.tex") as f:
     lines = f.readlines()
     with open(os.path.join(dest_path, 'figure_' + year, 'total_syst.tex'), "w") as f1:
         for line in lines:
-            if year != '2017' and 'Prefire' in line: continue
+            #if year != '2017' and 'Prefire' in line: continue
+            if 'Prefire' in line: continue
             for key, value in unc_summary.items():
                 if value in line:
                     with open(os.path.join(dest_path, 'figure_' + year, 'systematics_' + key + '.tex'),'r') as f2:

--- a/nanoaodframe/print_syst_table.py
+++ b/nanoaodframe/print_syst_table.py
@@ -91,6 +91,7 @@ for key, value in unc_cat.items():
                 if 'luminosity-error:' in line:
                     line = line[:line.find(':')+2]
                     line += "0.0\n"
+                    line += "  syst-only: true\n"
                 if 'root:' in line:
                     line = line[:line.find(':')+2]
                     line += "'" + os.path.join(dest_path, year + "_postprocess") + "'\n"

--- a/nanoaodframe/src/Linkdef.h
+++ b/nanoaodframe/src/Linkdef.h
@@ -12,6 +12,8 @@
 #pragma link C++ class std::vector<std::vector<float>>+;
 #pragma link C++ class ROOT::VecOps::RVec<float>+;
 #pragma link C++ class ROOT::VecOps::RVec<ROOT::VecOps::RVec<float>>+;
+#pragma link C++ class ROOT::VecOps::RVec<double>+;
+#pragma link C++ class ROOT::VecOps::RVec<ROOT::VecOps::RVec<double>>+;
 #pragma link C++ class std::vector<ROOT::Math::PtEtaPhiMVector>+;
 #pragma link C++ class NanoAODAnalyzerrdframe +;
 #pragma link C++ class LQtopAnalyzer +;

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -753,17 +753,17 @@ void NanoAODAnalyzerrdframe::applyBSFs(std::vector<string> jes_var) {
             for (size_t i=0; i<var.size(); i++) {
                 double bweight = 1.0;
                 auto newpt = pts[j]*jer[j][0];
-                if (newpt < 40) continue;
+                if (newpt > 40) {
+                    std::string unc = var[i];
+                    if (unc.find("cferr") != std::string::npos and hadflav[j] != 4) unc = "central";
+                    if (unc.find("cferr") == std::string::npos and hadflav[j] == 4) unc = "central";
 
-                std::string unc = var[i];
-                if (unc.find("cferr") != std::string::npos and hadflav[j] != 4) unc = "central";
-                if (unc.find("cferr") == std::string::npos and hadflav[j] == 4) unc = "central";
-
-                BTagEntry::JetFlavor hadfconv;
-                if      (hadflav[j]==5) hadfconv=BTagEntry::FLAV_B;
-                else if (hadflav[j]==4) hadfconv=BTagEntry::FLAV_C;
-                else                    hadfconv=BTagEntry::FLAV_UDSG;
-                bweight = _btagcalibreader.eval_auto_bounds(unc, hadfconv, fabs(etas[j]), newpt, btags[j]);
+                    BTagEntry::JetFlavor hadfconv;
+                    if      (hadflav[j]==5) hadfconv=BTagEntry::FLAV_B;
+                    else if (hadflav[j]==4) hadfconv=BTagEntry::FLAV_C;
+                    else                    hadfconv=BTagEntry::FLAV_UDSG;
+                    bweight = _btagcalibreader.eval_auto_bounds(unc, hadfconv, fabs(etas[j]), newpt, btags[j]);
+                }
                 bSFs.emplace_back(bweight);
             }
             out.emplace_back(bSFs);
@@ -784,16 +784,16 @@ void NanoAODAnalyzerrdframe::applyBSFs(std::vector<string> jes_var) {
             for (size_t i=0; i<var.size(); i++) {
                 double bweight = 1.0;
                 auto newpt = pts[j] * jes[j][i] * jer[j][0];
-                if (newpt < 40) continue;
+                if (newpt > 40) {
+                    std::string unc = var[i];
+                    if (hadflav[j] == 4) unc = "central";
 
-                std::string unc = var[i];
-                if (hadflav[j] == 4) unc = "central";
-
-                BTagEntry::JetFlavor hadfconv;
-                if      (hadflav[j]==5) hadfconv=BTagEntry::FLAV_B;
-                else if (hadflav[j]==4) hadfconv=BTagEntry::FLAV_C;
-                else                    hadfconv=BTagEntry::FLAV_UDSG;
-                bweight = _btagcalibreaderJes.eval_auto_bounds(unc, hadfconv, fabs(etas[j]), newpt, btags[j]);
+                    BTagEntry::JetFlavor hadfconv;
+                    if      (hadflav[j]==5) hadfconv=BTagEntry::FLAV_B;
+                    else if (hadflav[j]==4) hadfconv=BTagEntry::FLAV_C;
+                    else                    hadfconv=BTagEntry::FLAV_UDSG;
+                    bweight = _btagcalibreaderJes.eval_auto_bounds(unc, hadfconv, fabs(etas[j]), newpt, btags[j]);
+                }
                 bSFs.emplace_back(bweight);
             }
             out.emplace_back(bSFs);
@@ -825,10 +825,10 @@ void NanoAODAnalyzerrdframe::selectJets(std::vector<std::string> jes_var) {
 
         doubles out;
         out.reserve(perJetSF[0].size());
-
         for (size_t i=0; i<perJetSF[0].size(); i++) {
             double bSF = 1.0;
             for (size_t j=0; j<perJetSF.size(); j++) {
+                if (perJetSF[j].empty()) continue;
                 bSF *= perJetSF[j][i];
             }
             out.emplace_back(bSF);

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -821,11 +821,11 @@ void NanoAODAnalyzerrdframe::selectJets(std::vector<std::string> jes_var) {
     };
 
     // input vector: vec[pt][vars]
-    auto calcBSF = [this](doublesVec perJetSF)->doubles {
+    auto calcBSF = [this](doublesVec perJetSF, int nvar)->doubles {
 
         doubles out;
-        out.reserve(perJetSF[0].size());
-        for (size_t i=0; i<perJetSF[0].size(); i++) {
+        out.reserve(nvar);
+        for (size_t i=0; i<nvar; i++) {
             double bSF = 1.0;
             for (size_t j=0; j<perJetSF.size(); j++) {
                 if (perJetSF[j].empty()) continue;
@@ -929,10 +929,14 @@ void NanoAODAnalyzerrdframe::selectJets(std::vector<std::string> jes_var) {
                .Define("Jet_HT", "Sum(Jet_pt)");
 
     if (!_isData) {
+        int nbsf_var = btag_var.size();
+        int njes_var = jes_var.size();
         _rlm = _rlm.Redefine("btagWeight_DeepFlavB_perJet", skimCol, {"btagWeight_DeepFlavB_perJet", "jetoverlap"})
                    .Redefine("btagWeight_DeepFlavB_jes_perJet", skimCol, {"btagWeight_DeepFlavB_jes_perJet", "jetoverlap"})
-                   .Define("btagWeight_DeepFlavB", calcBSF, {"btagWeight_DeepFlavB_perJet"})
-                   .Define("btagWeight_DeepFlavB_jes", calcBSF, {"btagWeight_DeepFlavB_jes_perJet"});
+                   .Define("nbsf_var", [nbsf_var](){return int(nbsf_var);})
+                   .Define("njes_var", [njes_var](){return int(njes_var);})
+                   .Define("btagWeight_DeepFlavB", calcBSF, {"btagWeight_DeepFlavB_perJet", "nbsf_var"})
+                   .Define("btagWeight_DeepFlavB_jes", calcBSF, {"btagWeight_DeepFlavB_jes_perJet", "njes_var"});
     }
 
 

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -184,9 +184,8 @@ void NanoAODAnalyzerrdframe::setupAnalysis() {
         }
     } else {
         selectElectrons();
-        selectJets(jes_var);
         selectTaus();
-        removeOverlaps();
+        selectJets(jes_var);
     }
     defineMoreVars();
     defineCuts();
@@ -743,64 +742,99 @@ void NanoAODAnalyzerrdframe::applyBSFs(std::vector<string> jes_var) {
     _btagcalibreaderJes.load(_btagcalibJes, BTagEntry::FLAV_UDSG, "iterativefit");
 
     // function to calculate event weight for MC events based on DeepJet algorithm
-    auto btagweightgenerator = [this, _btagcalibreader](floats &pts, floats &etas, ints &hadflav, floats &btags, strings &var, floatsVec &jer)->doubles {
+    auto btagweightgenerator = [this, _btagcalibreader](floats &pts, floats &etas, ints &hadflav, floats &btags, strings &var, floatsVec &jer)->doublesVec {
 
         doubles bSFs;
-        for (std::string src : var) {
-            double bweight = 1.0;
-            for (unsigned int i=0; i<pts.size(); i++) {
-                auto newpt = pts[i]*jer[i][0];
+        bSFs.reserve(var.size());
+        doublesVec out;
+        out.reserve(pts.size());
+
+        for (unsigned int j=0; j<pts.size(); j++) {
+            for (size_t i=0; i<var.size(); i++) {
+                double bweight = 1.0;
+                auto newpt = pts[j]*jer[j][0];
                 if (newpt < 40) continue;
 
-                std::string unc = src;
-                if (src.find("cferr") != std::string::npos and hadflav[i] != 4) unc = "central";
-                if (src.find("cferr") == std::string::npos and hadflav[i] == 4) unc = "central";
+                std::string unc = var[i];
+                if (unc.find("cferr") != std::string::npos and hadflav[j] != 4) unc = "central";
+                if (unc.find("cferr") == std::string::npos and hadflav[j] == 4) unc = "central";
 
                 BTagEntry::JetFlavor hadfconv;
-                if      (hadflav[i]==5) hadfconv=BTagEntry::FLAV_B;
-                else if (hadflav[i]==4) hadfconv=BTagEntry::FLAV_C;
+                if      (hadflav[j]==5) hadfconv=BTagEntry::FLAV_B;
+                else if (hadflav[j]==4) hadfconv=BTagEntry::FLAV_C;
                 else                    hadfconv=BTagEntry::FLAV_UDSG;
-                double w = _btagcalibreader.eval_auto_bounds(unc, hadfconv, fabs(etas[i]), newpt, btags[i]);
-                bweight *= w;
+                bweight = _btagcalibreader.eval_auto_bounds(unc, hadfconv, fabs(etas[j]), newpt, btags[j]);
+                bSFs.emplace_back(bweight);
             }
-            bSFs.emplace_back(bweight);
+            out.emplace_back(bSFs);
+            bSFs.clear();
         }
-        return bSFs;
+        return out;
     };
 
     auto btagweightgeneratorJes = [this, _btagcalibreaderJes](floats &pts, floats &etas, ints &hadflav,
-                                  floats &btags, floatsVec jes, strings &var, floatsVec &jer)->doubles {
+                                  floats &btags, floatsVec jes, strings &var, floatsVec &jer)->doublesVec {
 
-       doubles bSFs;
-        for (size_t i=0; i<var.size(); i++) {
-            double bweight = 1.0;
-            std::string src = var[i];
+        doubles bSFs;
+        bSFs.reserve(var.size());
+        doublesVec out;
+        out.reserve(pts.size());
 
-            for (unsigned int j=0; j<pts.size(); j++) {
+        for (unsigned int j=0; j<pts.size(); j++) {
+            for (size_t i=0; i<var.size(); i++) {
+                double bweight = 1.0;
                 auto newpt = pts[j] * jes[j][i] * jer[j][0];
                 if (newpt < 40) continue;
 
-                std::string unc = src;
+                std::string unc = var[i];
                 if (hadflav[j] == 4) unc = "central";
 
                 BTagEntry::JetFlavor hadfconv;
                 if      (hadflav[j]==5) hadfconv=BTagEntry::FLAV_B;
                 else if (hadflav[j]==4) hadfconv=BTagEntry::FLAV_C;
                 else                    hadfconv=BTagEntry::FLAV_UDSG;
-                double w = _btagcalibreaderJes.eval_auto_bounds(unc, hadfconv, fabs(etas[j]), newpt, btags[j]);
-                bweight *= w;
+                bweight = _btagcalibreaderJes.eval_auto_bounds(unc, hadfconv, fabs(etas[j]), newpt, btags[j]);
+                bSFs.emplace_back(bweight);
             }
-            bSFs.emplace_back(bweight);
+            out.emplace_back(bSFs);
+            bSFs.clear();
         }
-        return bSFs;
+        return out;
     };
 
     cout << "Generate b-tagging weight" << endl;
-    _rlm = _rlm.Define("btagWeight_DeepFlavB", btagweightgenerator, {"Jet_pt", "Jet_eta", "Jet_hadronFlavour", "Jet_btagDeepFlavB", "btag_var", "Jet_jer"})
-               .Define("btagWeight_DeepFlavB_jes", btagweightgeneratorJes, {"Jet_pt", "Jet_eta", "Jet_hadronFlavour", "Jet_btagDeepFlavB", "Jet_pt_unc", "btag_jes_var", "Jet_jer"});
+    _rlm = _rlm.Define("btagWeight_DeepFlavB_perJet", btagweightgenerator, {"Jet_pt", "Jet_eta", "Jet_hadronFlavour", "Jet_btagDeepFlavB", "btag_var", "Jet_jer"})
+               .Define("btagWeight_DeepFlavB_jes_perJet", btagweightgeneratorJes, {"Jet_pt", "Jet_eta", "Jet_hadronFlavour", "Jet_btagDeepFlavB", "Jet_pt_unc", "btag_jes_var", "Jet_jer"});
 }
 
 void NanoAODAnalyzerrdframe::selectJets(std::vector<std::string> jes_var) {
+
+
+    // input vector: vec[pt][vars], for bSF
+    auto skimCol = [this](doublesVec toSkim, ints cut)->doublesVec {
+
+        doublesVec out;
+        for (size_t i=0; i<toSkim.size(); i++) {
+            if (cut[i] > 0) out.emplace_back(toSkim[i]);
+        }
+        return out;
+    };
+
+    // input vector: vec[pt][vars]
+    auto calcBSF = [this](doublesVec perJetSF)->doubles {
+
+        doubles out;
+        out.reserve(perJetSF[0].size());
+
+        for (size_t i=0; i<perJetSF[0].size(); i++) {
+            double bSF = 1.0;
+            for (size_t j=0; j<perJetSF.size(); j++) {
+                bSF *= perJetSF[j][i];
+            }
+            out.emplace_back(bSF);
+        }
+        return out;
+    };
 
     if (!_isData) {
 
@@ -857,8 +891,74 @@ void NanoAODAnalyzerrdframe::selectJets(std::vector<std::string> jes_var) {
                .Redefine("Jet_phi", "Jet_phi[jetcuts]")
                .Redefine("Jet_mass", "Jet_mass[jetcuts]")
                .Redefine("Jet_btagDeepFlavB", "Jet_btagDeepFlavB[jetcuts]")
-               .Redefine("nJet", "int(Jet_pt.size())")
                .Define("jet4vecs", ::gen4vec, {"Jet_pt", "Jet_eta", "Jet_phi", "Jet_mass"});
+
+    if (!_isData) {
+        _rlm = _rlm.Redefine("btagWeight_DeepFlavB_perJet", skimCol, {"btagWeight_DeepFlavB_perJet", "jetcuts"})
+                   .Redefine("btagWeight_DeepFlavB_jes_perJet", skimCol, {"btagWeight_DeepFlavB_jes_perJet", "jetcuts"});
+    }
+
+    // for checking overlapped jets with leptons
+    auto checkoverlap = [](FourVectorVec &seljets, FourVectorVec &sellep) {
+
+        doubles mindrlepton;
+        for (auto ajet: seljets) {
+            auto mindr = 6.0;
+            for ( auto alepton : sellep ) {
+                auto dr = ROOT::Math::VectorUtil::DeltaR(ajet, alepton);
+                if (dr < mindr) mindr = dr;
+            }
+            int out = mindr >= 0.4 ? 1 : 0;
+            mindrlepton.emplace_back(out);
+        }
+        return mindrlepton;
+    };
+
+    // Overlap removal with muon (used for btagging SF)
+    _rlm = _rlm.Define("muonjetoverlap", checkoverlap, {"jet4vecs","muon4vecs"})
+               .Define("taujetoverlap", checkoverlap, {"jet4vecs","cleantau4vecs"})
+               .Define("jetoverlap","muonjetoverlap && taujetoverlap");
+
+    _rlm = _rlm.Redefine("Jet_pt", "Jet_pt[jetoverlap]")
+               .Redefine("Jet_eta", "Jet_eta[jetoverlap]")
+               .Redefine("Jet_phi", "Jet_phi[jetoverlap]")
+               .Redefine("Jet_mass", "Jet_mass[jetoverlap]")
+               .Redefine("Jet_btagDeepFlavB", "Jet_btagDeepFlavB[jetoverlap]")
+               .Define("ncleanjetspass", "int(Jet_pt.size())")
+               .Define("cleanjet4vecs", ::gen4vec, {"Jet_pt", "Jet_eta", "Jet_phi", "Jet_mass"})
+               .Define("Jet_HT", "Sum(Jet_pt)");
+
+    if (!_isData) {
+        _rlm = _rlm.Redefine("btagWeight_DeepFlavB_perJet", skimCol, {"btagWeight_DeepFlavB_perJet", "jetoverlap"})
+                   .Redefine("btagWeight_DeepFlavB_jes_perJet", skimCol, {"btagWeight_DeepFlavB_jes_perJet", "jetoverlap"})
+                   .Define("btagWeight_DeepFlavB", calcBSF, {"btagWeight_DeepFlavB_perJet"})
+                   .Define("btagWeight_DeepFlavB_jes", calcBSF, {"btagWeight_DeepFlavB_jes_perJet"});
+    }
+
+
+    // b-tagging
+    if (_isRun16pre) {
+        //https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL16preVFP
+        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.2598"); //l: 0.0508, m: 0.2598, t: 0.6502
+    } else if (_isRun16post) {
+        //https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL16postVFP#AK4_b_tagging
+        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.2489"); //l: 0.0480, m: 0.2489, t: 0.6377
+    } else if (_isRun17) {
+        //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation106XUL17
+        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.3040"); //l: 0.0532, m: 0.3040, t: 0.7476
+    } else if (_isRun18) {
+        //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation106XUL18
+        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.2783"); //l: 0.0490, m: 0.2783, t: 0.7100
+    }
+
+    _rlm = _rlm.Define("bJet_pt", "Jet_pt[btagcuts]")
+               .Define("bJet_eta", "Jet_eta[btagcuts]")
+               .Define("bJet_phi", "Jet_phi[btagcuts]")
+               .Define("bJet_mass", "Jet_mass[btagcuts]")
+               .Define("bJet_btagDeepFlavB", "Jet_btagDeepFlavB[btagcuts]")
+               .Define("ncleanbjetspass", "int(bJet_pt.size())")
+               .Define("bJet_HT", "Sum(bJet_pt)")
+               .Define("cleanbjet4vecs", ::gen4vec, {"bJet_pt", "bJet_eta", "bJet_phi", "bJet_mass"});
 }
 
 void NanoAODAnalyzerrdframe::selectTaus() {
@@ -939,63 +1039,6 @@ void NanoAODAnalyzerrdframe::selectTaus() {
                    .Redefine("tauWeightIdVsEl", skimCol, {"tauWeightIdVsEl", "seltaucuts"})
                    .Redefine("tauWeightIdVsMu", skimCol, {"tauWeightIdVsMu", "seltaucuts"});
     }
-
-}
-
-void NanoAODAnalyzerrdframe::removeOverlaps() {
-
-    // for checking overlapped jets with leptons
-    auto checkoverlap = [](FourVectorVec &seljets, FourVectorVec &sellep) {
-
-        doubles mindrlepton;
-        for (auto ajet: seljets) {
-            auto mindr = 6.0;
-            for ( auto alepton : sellep ) {
-                auto dr = ROOT::Math::VectorUtil::DeltaR(ajet, alepton);
-                if (dr < mindr) mindr = dr;
-            }
-            int out = mindr >= 0.4 ? 1 : 0;
-            mindrlepton.emplace_back(out);
-        }
-        return mindrlepton;
-    };
-
-    // Overlap removal with muon (used for btagging SF)
-    _rlm = _rlm.Define("muonjetoverlap", checkoverlap, {"jet4vecs","muon4vecs"})
-               .Define("taujetoverlap", checkoverlap, {"jet4vecs","cleantau4vecs"})
-               .Define("jetoverlap","muonjetoverlap && taujetoverlap");
-
-    _rlm = _rlm.Redefine("Jet_pt", "Jet_pt[jetoverlap]")
-               .Redefine("Jet_eta", "Jet_eta[jetoverlap]")
-               .Redefine("Jet_phi", "Jet_phi[jetoverlap]")
-               .Redefine("Jet_mass", "Jet_mass[jetoverlap]")
-               .Redefine("Jet_btagDeepFlavB", "Jet_btagDeepFlavB[jetoverlap]")
-               .Define("ncleanjetspass", "int(Jet_pt.size())")
-               .Define("cleanjet4vecs", ::gen4vec, {"Jet_pt", "Jet_eta", "Jet_phi", "Jet_mass"})
-               .Define("Jet_HT", "Sum(Jet_pt)");
-
-    if (_isRun16pre) {
-        //https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL16preVFP
-        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.2598"); //l: 0.0508, m: 0.2598, t: 0.6502
-    } else if (_isRun16post) {
-        //https://twiki.cern.ch/twiki/bin/view/CMS/BtagRecommendation106XUL16postVFP#AK4_b_tagging
-        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.2489"); //l: 0.0480, m: 0.2489, t: 0.6377
-    } else if (_isRun17) {
-        //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation106XUL17
-        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.3040"); //l: 0.0532, m: 0.3040, t: 0.7476
-    } else if (_isRun18) {
-        //https://twiki.cern.ch/twiki/bin/viewauth/CMS/BtagRecommendation106XUL18
-        _rlm = _rlm.Define("btagcuts", "Jet_btagDeepFlavB>0.2783"); //l: 0.0490, m: 0.2783, t: 0.7100
-    }
-
-    _rlm = _rlm.Define("bJet_pt", "Jet_pt[btagcuts]")
-               .Define("bJet_eta", "Jet_eta[btagcuts]")
-               .Define("bJet_phi", "Jet_phi[btagcuts]")
-               .Define("bJet_mass", "Jet_mass[btagcuts]")
-               .Define("bJet_btagDeepFlavB", "Jet_btagDeepFlavB[btagcuts]")
-               .Define("ncleanbjetspass", "int(bJet_pt.size())")
-               .Define("bJet_HT", "Sum(bJet_pt)")
-               .Define("cleanbjet4vecs", ::gen4vec, {"bJet_pt", "bJet_eta", "bJet_phi", "bJet_mass"});
 
 }
 

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.h
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.h
@@ -51,7 +51,6 @@ public:
   void selectTaus();
   void selectMET();
   void selectFatJets();
-  void removeOverlaps();
   void matchGenReco();
   void calculateEvWeight();
   void storeEvWeight();

--- a/nanoaodframe/src/TopLFVAnalyzer.cpp
+++ b/nanoaodframe/src/TopLFVAnalyzer.cpp
@@ -112,7 +112,7 @@ void TopLFVAnalyzer::defineMoreVars() {
         addVar({"eventWeight_nobtag", "eventWeight_genpu * eventWeight_mu * eventWeight_tau"});
         addVar({"eventWeight_nopu", "unitGenWeight * eventWeight_mu * eventWeight_tau * btagWeight_DeepFlavB[0]"});
 
-        if (_syst == "" or ext_syst) {
+        if (_syst == "" or _syst == "nosyst" or ext_syst) {
             // for external syst, we only need nominal weight
             if (_syst.find("jesAbsoluteup") != std::string::npos) {
                 addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB_jes[0]"});
@@ -276,7 +276,8 @@ void TopLFVAnalyzer::defineMoreVars() {
     addVartoStore("MET_pt");
     addVartoStore("MET_phi");
     addVartoStore("chi2.*");
-    addVartoStore("btagWeight_DeepFlavB.*");
+    addVartoStore("btagWeight_DeepFlavB");
+    addVartoStore("btagWeight_DeepFlavB_jes");
     addVartoStore("eventWeight.*");
 }
 

--- a/nanoaodframe/src/utility.h
+++ b/nanoaodframe/src/utility.h
@@ -16,6 +16,7 @@
 using floats =  ROOT::VecOps::RVec<float>;
 using floatsVec =  ROOT::VecOps::RVec<ROOT::VecOps::RVec<float>>;
 using doubles =  ROOT::VecOps::RVec<double>;
+using doublesVec =  ROOT::VecOps::RVec<ROOT::VecOps::RVec<double>>;
 using ints =  ROOT::VecOps::RVec<int>;
 using bools = ROOT::VecOps::RVec<bool>;
 using uchars = ROOT::VecOps::RVec<unsigned char>;

--- a/nanoaodframe/test_branch.py
+++ b/nanoaodframe/test_branch.py
@@ -1,0 +1,20 @@
+import warnings
+warnings.filterwarnings("ignore")
+
+import os, sys
+import uproot
+import pandas as pd
+import numpy as np
+
+f_dir = sys.argv[1]
+
+#inputvars = ["btagWeight_DeepFlavB_perJet", 'Jet_pt', 'event'] #/data1/common/skimmed_NanoAOD/skim_test2/mc/2016pre/WJetsToLNu_HT1200To2500/280000_0C76D3EA-6565-B24B-B716-B9BB61B55D59.root
+inputvars = ["btagWeight_DeepFlavB_perJet", "btagWeight_DeepFlavB_jes_perJet", 'Jet_pt', 'event'] #/data1/common/skimmed_NanoAOD/skim_test2/mc/2016pre/WJetsToLNu_HT1200To2500/120000_6977F95D-BF50-DC4D-9CD6-A627B125DD39.root
+
+infile = uproot.open(f_dir)
+tree = infile["Events"]
+pd_data = tree.arrays(inputvars,library="pd")
+#pd_data = pd_data[pd_data['event']==165452]
+pd_data = pd_data[pd_data['event']==734551]
+with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.max_colwidth', None):
+    print(pd_data)

--- a/plotIt/configs/config_2016post.yml
+++ b/plotIt/configs/config_2016post.yml
@@ -29,11 +29,10 @@ systematics:
   - other_xsec1: {type: const, value: 1.1, on: 'DYJetsToLL'}
   - other_xsec2: {type: const, value: 1.1, on: 'ST_s'}
   - other_xsec3: {type: const, value: 1.1, on: 'ST_t'}
-  - other_xsec4: {type: const, value: 1.1, on: 'ST_tW'}
   - other_xsec5: {type: const, value: 1.1, on: 'ttH'}
   - other_xsec6: {type: const, value: 1.1, on: 'TTWJets'}
   - other_xsec7: {type: const, value: 1.1, on: 'TTZ'}
-  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu'}
+  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu_HT'}
   - other_xsec9: {type: const, value: 1.1, on: 'WW'}
   - other_xsec10: {type: const, value: 1.1, on: 'WZ'}
   - other_xsec11: {type: const, value: 1.1, on: 'ZZ'}

--- a/plotIt/configs/config_2016pre.yml
+++ b/plotIt/configs/config_2016pre.yml
@@ -29,11 +29,10 @@ systematics:
   - other_xsec1: {type: const, value: 1.1, on: 'DYJetsToLL'}
   - other_xsec2: {type: const, value: 1.1, on: 'ST_s'}
   - other_xsec3: {type: const, value: 1.1, on: 'ST_t'}
-  - other_xsec4: {type: const, value: 1.1, on: 'ST_tW'}
   - other_xsec5: {type: const, value: 1.1, on: 'ttH'}
   - other_xsec6: {type: const, value: 1.1, on: 'TTWJets'}
   - other_xsec7: {type: const, value: 1.1, on: 'TTZ'}
-  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu'}
+  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu_HT'}
   - other_xsec9: {type: const, value: 1.1, on: 'WW'}
   - other_xsec10: {type: const, value: 1.1, on: 'WZ'}
   - other_xsec11: {type: const, value: 1.1, on: 'ZZ'}

--- a/plotIt/configs/config_2017.yml
+++ b/plotIt/configs/config_2017.yml
@@ -29,11 +29,10 @@ systematics:
   - other_xsec1: {type: const, value: 1.1, on: 'DYJetsToLL'}
   - other_xsec2: {type: const, value: 1.1, on: 'ST_s'}
   - other_xsec3: {type: const, value: 1.1, on: 'ST_t'}
-  - other_xsec4: {type: const, value: 1.1, on: 'ST_tW'}
   - other_xsec5: {type: const, value: 1.1, on: 'ttH'}
   - other_xsec6: {type: const, value: 1.1, on: 'TTWJets'}
   - other_xsec7: {type: const, value: 1.1, on: 'TTZ'}
-  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu'}
+  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu_HT'}
   - other_xsec9: {type: const, value: 1.1, on: 'WW'}
   - other_xsec10: {type: const, value: 1.1, on: 'WZ'}
   - other_xsec11: {type: const, value: 1.1, on: 'ZZ'}

--- a/plotIt/configs/config_2018.yml
+++ b/plotIt/configs/config_2018.yml
@@ -29,11 +29,10 @@ systematics:
   - other_xsec1: {type: const, value: 1.1, on: 'DYJetsToLL'}
   - other_xsec2: {type: const, value: 1.1, on: 'ST_s'}
   - other_xsec3: {type: const, value: 1.1, on: 'ST_t'}
-  - other_xsec4: {type: const, value: 1.1, on: 'ST_tW'}
   - other_xsec5: {type: const, value: 1.1, on: 'ttH'}
   - other_xsec6: {type: const, value: 1.1, on: 'TTWJets'}
   - other_xsec7: {type: const, value: 1.1, on: 'TTZ'}
-  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu'}
+  - other_xsec8: {type: const, value: 1.1, on: 'WJetsToLNu_HT'}
   - other_xsec9: {type: const, value: 1.1, on: 'WW'}
   - other_xsec10: {type: const, value: 1.1, on: 'WZ'}
   - other_xsec11: {type: const, value: 1.1, on: 'ZZ'}

--- a/plotIt/configs/files_2016post.yml
+++ b/plotIt/configs/files_2016post.yml
@@ -102,7 +102,7 @@
 'hist_TTToSemiLeptonic.root':
   type: mc
   pretty-name: 'TTToSemiLeptonic'
-  cross-section: 365.34
+  cross-section: 366.34
   generated-events: 157314692.0
   group: Gttlj
   yields-group: '2\ttbar LJ'
@@ -111,7 +111,7 @@
 'hist_TTTo2L2Nu.root':
   type: mc
   pretty-name: 'TTTo2L2Nu'
-  cross-section: 88.29
+  cross-section: 88.51
   generated-events: 47092114.0
   group: Gttll
   yields-group: '1\ttbar LL'
@@ -120,7 +120,7 @@
 'hist_TTToHadronic.root':
   type: mc
   pretty-name: 'TTToHadronic'
-  cross-section: 377.96
+  cross-section: 379.05
   generated-events: 111680750.0
   group: Gttjj
   yields-group: '3\ttbar Had'
@@ -129,7 +129,7 @@
 #'hist_ttHJetTobb.root':
 #  type: mc
 #  pretty-name: 'ttHTobb'
-#  cross-section: 0.5023
+#  cross-section: 0.2934
 #  generated-events: #FIXME
 #  group: GttV
 #  yields-group: '7tt+X'
@@ -138,7 +138,7 @@
 #'hist_ttHJetToNonbb.root':
 #  type: mc
 #  pretty-name: 'ttHToNonbb'
-#  cross-section: 0.5066
+#  cross-section: 0.2151
 #  generated-events: #FIXME
 #  group: GttV
 #  yields-group: '7tt+X'
@@ -147,7 +147,7 @@
 'hist_TTWJetsToLNu.root':
   type: mc
   pretty-name: 'TTWJetsToLNu'
-  cross-section: 0.2043
+  cross-section: 0.2529
   generated-events: 400706.0
   group: GttV
   yields-group: '7tt+X'
@@ -156,7 +156,7 @@
 'hist_TTWJetsToQQ.root':
   type: mc
   pretty-name: 'TTWJetsToQQ'
-  cross-section: 0.4062
+  cross-section: 0.5297
   generated-events: 168951.0
   group: GttV
   yields-group: '7tt+X'
@@ -183,7 +183,7 @@
 'hist_ST_s_4f_lepton.root':
   type: mc
   pretty-name: 'SingleTops'
-  cross-section: 3.36
+  cross-section: 2.23
   generated-events: 4085988.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -192,7 +192,7 @@
 'hist_ST_t_top_4f.root':
   type: mc
   pretty-name: 'SingleTopt'
-  cross-section: 136.02
+  cross-section: 134.2
   generated-events: 58866028.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -201,7 +201,7 @@
 'hist_ST_t_antitop_4f.root':
   type: mc
   pretty-name: 'SingleTbart'
-  cross-section: 80.95
+  cross-section: 80.0
   generated-events: 28677096.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -210,7 +210,7 @@
 'hist_ST_tW_top_5f.root':
   type: mc
   pretty-name: 'SingleToptW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 2433862.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -219,7 +219,7 @@
 'hist_ST_tW_antitop_5f.root':
   type: mc
   pretty-name: 'SingleTbartW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 2523884.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -246,7 +246,7 @@
 'hist_ZZ.root':
   type: mc
   pretty-name: 'ZZ'
-  cross-section: 16.523
+  cross-section: 16.91
   generated-events: 1114000.0
   group: GVV
   yields-group: '8VV'
@@ -273,7 +273,7 @@
 'hist_WJetsToLNu_HT0To100.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
-  cross-section: 59373.3
+  cross-section: 65396.85 # 67350.0 * 0.972
   generated-events: 85986988.0 # total 88463979.0 * 0.972
   group: GWJets
   yields-group: '6W+Jets'
@@ -282,7 +282,7 @@
 'hist_WJetsToLNu_HT100To200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
-  cross-section: 1335.585
+  cross-section: 1519.76 # 1256.0 * 1.21 * 1.000
   generated-events: 19616492.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -291,7 +291,7 @@
 'hist_WJetsToLNu_HT200To400.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
-  cross-section: 360.4194
+  cross-section: 407.98 # 335.5 * 1.21 * 1.005
   generated-events: 16584072.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -300,7 +300,7 @@
 'hist_WJetsToLNu_HT400To600.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
-  cross-section: 49.35019
+  cross-section: 53.986 # 45.25 * 1.21 * 0.986
   generated-events: 2237687.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -309,7 +309,7 @@
 'hist_WJetsToLNu_HT600To800.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
-  cross-section: 13.4960
+  cross-section: 13.91 # 12.05 * 1.21 * 0.954
   generated-events: 2205351.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -318,7 +318,7 @@
 'hist_WJetsToLNu_HT800To1200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
-  cross-section: 6.612202
+  cross-section: 6.19 # 5.501 * 1.21 * 0.930
   generated-events: 2190406.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -327,7 +327,7 @@
 'hist_WJetsToLNu_HT1200To2500.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
-  cross-section: 1.770228
+  cross-section: 1.199 # 1.16 * 1.21 * 0.854
   generated-events: 2090561.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -336,7 +336,7 @@
 'hist_WJetsToLNu_HT2500ToInf.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
-  cross-section: 0.135072
+  cross-section: 0.0267 # 0.026 * 1.21 * 0.849
   generated-events: 677141.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -345,7 +345,7 @@
 #'hist_QCD_Pt15To20_MuEnriched.root':
 #  type: mc
 #  pretty-name: 'QCD'
-#  cross-section: 
+#  cross-section: 2797000.0
 #  generated-events:
 #  group: GQCD
 #  yields-group: '9QCD'
@@ -354,7 +354,7 @@
 'hist_QCD_Pt20To30_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 2960198.4
+  cross-section: 2518000.0
   generated-events: 30255176.0
   group: GQCD
   yields-group: '9QCD'
@@ -363,7 +363,7 @@
 'hist_QCD_Pt30To50_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1652471.5
+  cross-section: 1361000.0
   generated-events: 35397812.0
   group: GQCD
   yields-group: '9QCD'
@@ -372,7 +372,7 @@
 'hist_QCD_Pt50To80_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 437504.1
+  cross-section: 377800.0
   generated-events: 22279218.0
   group: GQCD
   yields-group: '9QCD'
@@ -381,7 +381,7 @@
 'hist_QCD_Pt80To120_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 106033.7
+  cross-section: 88620.0
   generated-events: 23407998.0
   group: GQCD
   yields-group: '9QCD'
@@ -390,7 +390,7 @@
 'hist_QCD_Pt120To170_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25190.5
+  cross-section: 21070.0
   generated-events: 19763172.0
   group: GQCD
   yields-group: '9QCD'
@@ -399,7 +399,7 @@
 'hist_QCD_Pt170To300_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 8654.5
+  cross-section: 7019.0
   generated-events: 36800197.0
   group: GQCD
   yields-group: '9QCD'
@@ -408,7 +408,7 @@
 'hist_QCD_Pt300To470_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 797.4
+  cross-section: 622.4
   generated-events: 30061697.0
   group: GQCD
   yields-group: '9QCD'
@@ -417,7 +417,7 @@
 'hist_QCD_Pt470To600_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 79.0
+  cross-section: 58.86
   generated-events: 20185257.0
   group: GQCD
   yields-group: '9QCD'
@@ -426,7 +426,7 @@
 'hist_QCD_Pt600To800_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25.1
+  cross-section: 18.22
   generated-events: 19553333.0
   group: GQCD
   yields-group: '9QCD'
@@ -435,7 +435,7 @@
 'hist_QCD_Pt800To1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 4.7
+  cross-section: 3.25
   generated-events: 41592873.0
   group: GQCD
   yields-group: '9QCD'
@@ -444,7 +444,7 @@
 'hist_QCD_Pt1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1.6
+  cross-section: 1.078
   generated-events: 14243204.0
   group: GQCD
   yields-group: '9QCD'

--- a/plotIt/configs/files_2016pre.yml
+++ b/plotIt/configs/files_2016pre.yml
@@ -102,7 +102,7 @@
 'hist_TTToSemiLeptonic.root':
   type: mc
   pretty-name: 'TTToSemiLeptonic'
-  cross-section: 365.34
+  cross-section: 366.34
   generated-events: 137049180.0
   group: Gttlj
   yields-group: '2\ttbar LJ'
@@ -111,7 +111,7 @@
 'hist_TTTo2L2Nu.root':
   type: mc
   pretty-name: 'TTTo2L2Nu'
-  cross-section: 88.29
+  cross-section: 88.51
   generated-events: 41030018.0
   group: Gttll
   yields-group: '1\ttbar LL'
@@ -120,7 +120,7 @@
 'hist_TTToHadronic.root':
   type: mc
   pretty-name: 'TTToHadronic'
-  cross-section: 377.96
+  cross-section: 379.05
   generated-events: 97033134.0
   group: Gttjj
   yields-group: '3\ttbar Had'
@@ -129,7 +129,7 @@
 #'hist_ttHJetTobb.root':
 #  type: mc
 #  pretty-name: 'ttHTobb'
-#  cross-section: 0.5023
+#  cross-section: 0.2934
 #  generated-events: #FIXME
 #  group: GttV
 #  yields-group: '7tt+X'
@@ -138,7 +138,7 @@
 #'hist_ttHJetToNonbb.root':
 #  type: mc
 #  pretty-name: 'ttHToNonbb'
-#  cross-section: 0.5066
+#  cross-section: 0.2151
 #  generated-events: #FIXME
 #  group: GttV
 #  yields-group: '7tt+X'
@@ -147,7 +147,7 @@
 'hist_TTWJetsToLNu.root':
   type: mc
   pretty-name: 'TTWJetsToLNu'
-  cross-section: 0.2043
+  cross-section: 0.2529
   generated-events: 1555729.0
   group: GttV
   yields-group: '7tt+X'
@@ -156,7 +156,7 @@
 'hist_TTWJetsToQQ.root':
   type: mc
   pretty-name: 'TTWJetsToQQ'
-  cross-section: 0.4062
+  cross-section: 0.5297
   generated-events: 168842.0
   group: GttV
   yields-group: '7tt+X'
@@ -183,7 +183,7 @@
 'hist_ST_s_4f_lepton.root':
   type: mc
   pretty-name: 'SingleTops'
-  cross-section: 3.36
+  cross-section: 2.23
   generated-events: 3688762.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -192,7 +192,7 @@
 'hist_ST_t_top_4f.root':
   type: mc
   pretty-name: 'SingleTopt'
-  cross-section: 136.02
+  cross-section: 134.2
   generated-events: 52437432.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -201,7 +201,7 @@
 'hist_ST_t_antitop_4f.root':
   type: mc
   pretty-name: 'SingleTbart'
-  cross-section: 80.95
+  cross-section: 80.0
   generated-events: 29205918.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -210,7 +210,7 @@
 'hist_ST_tW_top_5f.root':
   type: mc
   pretty-name: 'SingleToptW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 2299880.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -219,7 +219,7 @@
 'hist_ST_tW_antitop_5f.root':
   type: mc
   pretty-name: 'SingleTbartW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 2299866.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -246,7 +246,7 @@
 'hist_ZZ.root':
   type: mc
   pretty-name: 'ZZ'
-  cross-section: 16.523
+  cross-section: 16.91
   generated-events: 1270000.0
   group: GVV
   yields-group: '8VV'
@@ -270,10 +270,19 @@
   yields-group: '4Z+Jets'
   order: 24
 
+#'hist_WJetsToLNu_incl.root':
+#  type: mc
+#  pretty-name: 'WJetsToLNu_incl'
+#  cross-section: 67350.0
+#  generated-events: 75142187
+#  group: GWJets
+#  yields-group: '6W+Jets'
+#  order: 25
+
 'hist_WJetsToLNu_HT0To100.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
-  cross-section: 59373.3
+  cross-section: 65396.85 # 67350.0 * 0.972
   generated-events: 73038206.0 # 75142187.0 * 0.972 (htcut)
   group: GWJets
   yields-group: '6W+Jets'
@@ -282,7 +291,7 @@
 'hist_WJetsToLNu_HT100To200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
-  cross-section: 1335.585
+  cross-section: 1519.76 # 1256.0 * 1.21 * 1.000
   generated-events: 21756477.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -291,7 +300,7 @@
 'hist_WJetsToLNu_HT200To400.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
-  cross-section: 360.4194
+  cross-section: 407.98 # 335.5 * 1.21 * 1.005
   generated-events: 227131.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -300,7 +309,7 @@
 'hist_WJetsToLNu_HT400To600.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
-  cross-section: 49.35019
+  cross-section: 53.986 # 45.25 * 1.21 * 0.986
   generated-events: 2507514.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -309,7 +318,7 @@
 'hist_WJetsToLNu_HT600To800.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
-  cross-section: 13.4960
+  cross-section: 13.91 # 12.05 * 1.21 * 0.954
   generated-events: 2402595.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -318,7 +327,7 @@
 'hist_WJetsToLNu_HT800To1200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
-  cross-section: 6.612202
+  cross-section: 6.19 # 5.501 * 1.21 * 0.930
   generated-events: 2494564.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -327,7 +336,7 @@
 'hist_WJetsToLNu_HT1200To2500.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
-  cross-section: 1.770228
+  cross-section: 1.199 # 1.16 * 1.21 * 0.854
   generated-events: 2119975.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -336,7 +345,7 @@
 'hist_WJetsToLNu_HT2500ToInf.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
-  cross-section: 0.135072
+  cross-section: 0.0267 # 0.026 * 1.21 * 0.849
   generated-events: 807531.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -345,7 +354,7 @@
 #'hist_QCD_Pt15To20_MuEnriched.root':
 #  type: mc
 #  pretty-name: 'QCD'
-#  cross-section: 3819570.0
+#  cross-section: 2797000.0
 #  generated-events:
 #  group: GQCD
 #  yields-group: '9QCD'
@@ -354,7 +363,7 @@
 'hist_QCD_Pt20To30_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 2960198.4
+  cross-section: 2518000.0
   generated-events: 31521458.0
   group: GQCD
   yields-group: '9QCD'
@@ -363,7 +372,7 @@
 'hist_QCD_Pt30To50_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1652471.5
+  cross-section: 1361000.0
   generated-events: 28467772.0
   group: GQCD
   yields-group: '9QCD'
@@ -372,7 +381,7 @@
 'hist_QCD_Pt50To80_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 437504.1
+  cross-section: 377800.0
   generated-events: 19668811.0
   group: GQCD
   yields-group: '9QCD'
@@ -381,7 +390,7 @@
 'hist_QCD_Pt80To120_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 106033.7
+  cross-section: 88620.0
   generated-events: 22132145.0
   group: GQCD
   yields-group: '9QCD'
@@ -390,7 +399,7 @@
 'hist_QCD_Pt120To170_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25190.5
+  cross-section: 21070.0
   generated-events: 19239358.0
   group: GQCD
   yields-group: '9QCD'
@@ -399,7 +408,7 @@
 'hist_QCD_Pt170To300_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 8654.5
+  cross-section: 7019.0
   generated-events: 36728058.0
   group: GQCD
   yields-group: '9QCD'
@@ -408,7 +417,7 @@
 'hist_QCD_Pt300To470_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 797.4
+  cross-section: 622.4
   generated-events: 29595276.0
   group: GQCD
   yields-group: '9QCD'
@@ -417,7 +426,7 @@
 'hist_QCD_Pt470To600_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 79.0
+  cross-section: 58.86
   generated-events: 20128914.0
   group: GQCD
   yields-group: '9QCD'
@@ -426,7 +435,7 @@
 'hist_QCD_Pt600To800_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25.1
+  cross-section: 18.22
   generated-events: 19658498.0
   group: GQCD
   yields-group: '9QCD'
@@ -435,7 +444,7 @@
 'hist_QCD_Pt800To1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 4.7
+  cross-section: 3.25
   generated-events: 39682082.0
   group: GQCD
   yields-group: '9QCD'
@@ -444,7 +453,7 @@
 'hist_QCD_Pt1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1.6
+  cross-section: 1.078
   generated-events: 14189415.0
   group: GQCD
   yields-group: '9QCD'

--- a/plotIt/configs/files_2017.yml
+++ b/plotIt/configs/files_2017.yml
@@ -102,7 +102,7 @@
 'hist_TTToSemiLeptonic.root':
   type: mc
   pretty-name: 'TTToSemiLeptonic'
-  cross-section: 365.34
+  cross-section: 366.34
   generated-events: 355826000.0
   group: Gttlj
   yields-group: '2\ttbar LJ'
@@ -111,7 +111,7 @@
 'hist_TTTo2L2Nu.root':
   type: mc
   pretty-name: 'TTTo2L2Nu'
-  cross-section: 88.29
+  cross-section: 88.51
   generated-events: 106978000.0
   group: Gttll
   yields-group: '1\ttbar LL'
@@ -120,7 +120,7 @@
 'hist_TTToHadronic.root':
   type: mc
   pretty-name: 'TTToHadronic'
-  cross-section: 377.96
+  cross-section: 379.05
   generated-events: 246712999.0
   group: Gttjj
   yields-group: '3\ttbar Had'
@@ -129,7 +129,7 @@
 'hist_ttHJetTobb.root':
   type: mc
   pretty-name: 'ttHTobb'
-  cross-section: 0.5023
+  cross-section: 0.2934
   generated-events: 11590377
   group: GttV
   yields-group: '7tt+X'
@@ -138,7 +138,7 @@
 'hist_ttHJetToNonbb.root':
   type: mc
   pretty-name: 'ttHToNonbb'
-  cross-section: 0.5066
+  cross-section: 0.2151
   generated-events: 7368333
   group: GttV
   yields-group: '7tt+X'
@@ -147,7 +147,7 @@
 'hist_TTWJetsToLNu.root':
   type: mc
   pretty-name: 'TTWJetsToLNu'
-  cross-section: 0.2043
+  cross-section: 0.2529
   generated-events: 7464889.0
   group: GttV
   yields-group: '7tt+X'
@@ -156,7 +156,7 @@
 'hist_TTWJetsToQQ.root':
   type: mc
   pretty-name: 'TTWJetsToQQ'
-  cross-section: 0.4062
+  cross-section: 0.5297
   generated-events: 688849.0
   group: GttV
   yields-group: '7tt+X'
@@ -183,7 +183,7 @@
 'hist_ST_s_4f_lepton.root':
   type: mc
   pretty-name: 'SingleTops'
-  cross-section: 3.36
+  cross-section: 2.23
   generated-events: 12447484
   group: GSingleT
   yields-group: '5Single Top'
@@ -192,7 +192,7 @@
 'hist_ST_t_top_4f.root':
   type: mc
   pretty-name: 'SingleTopt'
-  cross-section: 136.02
+  cross-section: 134.2
   generated-events: 126808000.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -201,7 +201,7 @@
 'hist_ST_t_antitop_4f.root':
   type: mc
   pretty-name: 'SingleTbart'
-  cross-section: 80.95
+  cross-section: 80.0
   generated-events: 69189000.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -210,7 +210,7 @@
 'hist_ST_tW_top_5f.root':
   type: mc
   pretty-name: 'SingleToptW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 5669000.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -219,7 +219,7 @@
 'hist_ST_tW_antitop_5f.root':
   type: mc
   pretty-name: 'SingleTbartW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 5518000.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -246,7 +246,7 @@
 'hist_ZZ.root':
   type: mc
   pretty-name: 'ZZ'
-  cross-section: 16.523
+  cross-section: 16.91
   generated-events: 2708000.0
   group: GVV
   yields-group: '8VV'
@@ -273,8 +273,8 @@
 'hist_WJetsToLNu_HT0To100.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
-  cross-section: 59373.3
-  generated-events: 81254459.0 
+  cross-section: 65396.85 # 67350.0 * 0.972
+  generated-events: 78979334.0 # 81254459 * 0.972
   group: GWJets
   yields-group: '6W+Jets'
   order: 25
@@ -282,7 +282,7 @@
 'hist_WJetsToLNu_HT100To200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
-  cross-section: 1335.585
+  cross-section: 1519.76 # 1256.0 * 1.21 * 1.000
   generated-events: 47691676.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -291,7 +291,7 @@
 'hist_WJetsToLNu_HT200To400.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
-  cross-section: 360.4194
+  cross-section: 407.98 # 335.5 * 1.21 * 1.005
   generated-events: 42400350.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -300,7 +300,7 @@
 'hist_WJetsToLNu_HT400To600.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
-  cross-section: 49.35019
+  cross-section: 53.986 # 45.25 * 1.21 * 0.986
   generated-events: 5470704.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -309,7 +309,7 @@
 'hist_WJetsToLNu_HT600To800.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
-  cross-section: 13.4960
+  cross-section: 13.91 # 12.05 * 1.21 * 0.954
   generated-events: 5484477.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -318,7 +318,7 @@
 'hist_WJetsToLNu_HT800To1200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
-  cross-section: 6.612202
+  cross-section: 6.19 # 5.501 * 1.21 * 0.930
   generated-events: 5389834.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -327,7 +327,7 @@
 'hist_WJetsToLNu_HT1200To2500.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
-  cross-section: 1.770228
+  cross-section: 1.199 # 1.16 * 1.21 * 0.854
   generated-events: 4935967.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -336,7 +336,7 @@
 'hist_WJetsToLNu_HT2500ToInf.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
-  cross-section: 0.135072
+  cross-section: 0.0267 # 0.026 * 1.21 * 0.849
   generated-events: 1185699.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -345,7 +345,7 @@
 #'hist_QCD_Pt15To20_MuEnriched.root':
 #  type: mc
 #  pretty-name: 'QCD'
-#  cross-section: 3819570.0
+#  cross-section: 2797000.0
 #  generated-events: 8989902.0
 #  group: GQCD
 #  yields-group: '9QCD'
@@ -354,7 +354,7 @@
 'hist_QCD_Pt20To30_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 2960198.4
+  cross-section: 2518000.0
   generated-events: 63651596.0
   group: GQCD
   yields-group: '9QCD'
@@ -363,7 +363,7 @@
 'hist_QCD_Pt30To50_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1652471.5
+  cross-section: 1361000.0
   generated-events: 58595659.0
   group: GQCD
   yields-group: '9QCD'
@@ -372,7 +372,7 @@
 'hist_QCD_Pt50To80_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 437504.1
+  cross-section: 377800.0
   generated-events: 40002811.0
   group: GQCD
   yields-group: '9QCD'
@@ -381,7 +381,7 @@
 'hist_QCD_Pt80To120_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 106033.7
+  cross-section: 88620.0
   generated-events: 45587818.0
   group: GQCD
   yields-group: '9QCD'
@@ -390,7 +390,7 @@
 'hist_QCD_Pt120To170_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25190.5
+  cross-section: 21070.0
   generated-events: 39406203.0
   group: GQCD
   yields-group: '9QCD'
@@ -399,7 +399,7 @@
 'hist_QCD_Pt170To300_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 8654.5
+  cross-section: 7019.0
   generated-events: 73066072.0
   group: GQCD
   yields-group: '9QCD'
@@ -408,7 +408,7 @@
 'hist_QCD_Pt300To470_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 797.4
+  cross-section: 622.4
   generated-events: 58597948.0
   group: GQCD
   yields-group: '9QCD'
@@ -417,7 +417,7 @@
 'hist_QCD_Pt470To600_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 79.0
+  cross-section: 58.86
   generated-events: 39816804.0
   group: GQCD
   yields-group: '9QCD'
@@ -426,7 +426,7 @@
 'hist_QCD_Pt600To800_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25.1
+  cross-section: 18.22
   generated-events: 39326156.0
   group: GQCD
   yields-group: '9QCD'
@@ -435,7 +435,7 @@
 'hist_QCD_Pt800To1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 4.7
+  cross-section: 3.25
   generated-events: 78171998.0
   group: GQCD
   yields-group: '9QCD'
@@ -444,7 +444,7 @@
 'hist_QCD_Pt1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1.6
+  cross-section: 1.078
   generated-events: 27537497.0
   group: GQCD
   yields-group: '9QCD'

--- a/plotIt/configs/files_2018.yml
+++ b/plotIt/configs/files_2018.yml
@@ -102,7 +102,7 @@
 'hist_TTToSemiLeptonic.root':
   type: mc
   pretty-name: 'TTToSemiLeptonic'
-  cross-section: 365.34
+  cross-section: 366.34
   generated-events: 482836098.0
   group: Gttlj
   yields-group: '2\ttbar LJ'
@@ -111,7 +111,7 @@
 'hist_TTTo2L2Nu.root':
   type: mc
   pretty-name: 'TTTo2L2Nu'
-  cross-section: 88.29
+  cross-section: 88.51
   generated-events: 147271052.0
   group: Gttll
   yields-group: '1\ttbar LL'
@@ -120,7 +120,7 @@
 'hist_TTToHadronic.root':
   type: mc
   pretty-name: 'TTToHadronic'
-  cross-section: 377.96
+  cross-section: 379.05
   generated-events: 337254908.0
   group: Gttjj
   yields-group: '3\ttbar Had'
@@ -129,7 +129,7 @@
 'hist_ttHJetTobb.root':
   type: mc
   pretty-name: 'ttHTobb'
-  cross-section: 0.5023
+  cross-section: 0.2934
   generated-events: 3258053.0
   group: GttV
   yields-group: '7tt+X'
@@ -138,7 +138,7 @@
 'hist_ttHJetToNonbb.root':
   type: mc
   pretty-name: 'ttHToNonbb'
-  cross-section: 0.5066
+  cross-section: 0.2151
   generated-events: 3283863.0
   group: GttV
   yields-group: '7tt+X'
@@ -147,7 +147,7 @@
 'hist_TTWJetsToLNu.root':
   type: mc
   pretty-name: 'TTWJetsToLNu'
-  cross-section: 0.2043
+  cross-section: 0.2529
   generated-events: 5706163.0
   group: GttV
   yields-group: '7tt+X'
@@ -156,7 +156,7 @@
 'hist_TTWJetsToQQ.root':
   type: mc
   pretty-name: 'TTWJetsToQQ'
-  cross-section: 0.4062
+  cross-section: 0.5297
   generated-events: 530327.0
   group: GttV
   yields-group: '7tt+X'
@@ -183,7 +183,7 @@
 'hist_ST_s_4f_lepton.root':
   type: mc
   pretty-name: 'SingleTops'
-  cross-section: 3.36
+  cross-section: 2.23
   generated-events: 12993045.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -192,7 +192,7 @@
 'hist_ST_t_top_4f.root':
   type: mc
   pretty-name: 'SingleTopt'
-  cross-section: 136.02
+  cross-section: 134.2
   generated-events: 165365582.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -201,7 +201,7 @@
 'hist_ST_t_antitop_4f.root':
   type: mc
   pretty-name: 'SingleTbart'
-  cross-section: 80.95
+  cross-section: 80.0
   generated-events: 89304382.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -210,7 +210,7 @@
 'hist_ST_tW_top_5f.root':
   type: mc
   pretty-name: 'SingleToptW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 5978718.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -219,7 +219,7 @@
 'hist_ST_tW_antitop_5f.root':
   type: mc
   pretty-name: 'SingleTbartW'
-  cross-section: 35.85
+  cross-section: 39.65
   generated-events: 5779768.0
   group: GSingleT
   yields-group: '5Single Top'
@@ -246,7 +246,7 @@
 'hist_ZZ.root':
   type: mc
   pretty-name: 'ZZ'
-  cross-section: 16.523
+  cross-section: 16.91
   generated-events: 3907000.0
   group: GVV
   yields-group: '8VV'
@@ -270,19 +270,29 @@
   yields-group: '4Z+Jets'
   order: 24
 
+#'hist_WJetsToLNu_incl.root':
+#  type: mc
+#  pretty-name: 'WJetsToLNu_incl'
+#  cross-section: 67350.0
+#  generated-events: 83009353
+#  group: GWJets
+#  yields-group: '6W+Jets'
+#  order: 25
+
 'hist_WJetsToLNu_HT0To100.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
-  cross-section: 59373.3
-  generated-events: 79688979 # total * 0.96 (htcut)
+  cross-section: 65396.85 # 67350.0 * 0.972
+  generated-events: 80685091.0 # 83009353 * 0.972 (htcut)
   group: GWJets
   yields-group: '6W+Jets'
   order: 25
+  # 65396.85 ~ 65346.9483 = 67350.0 - 1519.76 - 407.98 - 53.986 - 13.91 - 6.19 - 1.199 - 0.0267 (0.076%)
 
 'hist_WJetsToLNu_HT100To200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
-  cross-section: 1335.585
+  cross-section: 1519.76 # 1256.0 * 1.21 * 1.000
   generated-events: 66195407.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -291,7 +301,7 @@
 'hist_WJetsToLNu_HT200To400.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
-  cross-section: 360.4194
+  cross-section: 407.98 # 335.5 * 1.21 * 1.005
   generated-events: 56898682.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -300,7 +310,7 @@
 'hist_WJetsToLNu_HT400To600.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
-  cross-section: 49.35019
+  cross-section: 53.986 # 45.25 * 1.21 * 0.986
   generated-events: 7545618.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -309,7 +319,7 @@
 'hist_WJetsToLNu_HT600To800.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
-  cross-section: 13.4960
+  cross-section: 13.91 # 12.05 * 1.21 * 0.954
   generated-events: 7556181.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -318,7 +328,7 @@
 'hist_WJetsToLNu_HT800To1200.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
-  cross-section: 6.612202
+  cross-section: 6.19 # 5.501 * 1.21 * 0.930
   generated-events: 7418726.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -327,7 +337,7 @@
 'hist_WJetsToLNu_HT1200To2500.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
-  cross-section: 1.770228
+  cross-section: 1.199 # 1.16 * 1.21 * 0.854
   generated-events: 6855219.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -336,7 +346,7 @@
 'hist_WJetsToLNu_HT2500ToInf.root':
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
-  cross-section: 0.135072
+  cross-section: 0.0267 # 0.026 * 1.21 * 0.849
   generated-events: 2097648.0
   group: GWJets
   yields-group: '6W+Jets'
@@ -345,7 +355,7 @@
 #'hist_QCD_Pt15To20_MuEnriched.root':
 #  type: mc
 #  pretty-name: 'QCD'
-#  cross-section: 3819570.0
+#  cross-section: 2797000.0
 #  generated-events:
 #  group: GQCD
 #  yields-group: '9QCD'
@@ -354,7 +364,7 @@
 'hist_QCD_Pt20To30_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 2960198.4
+  cross-section: 2518000.0
   generated-events: 60662268.0
   group: GQCD
   yields-group: '9QCD'
@@ -363,7 +373,7 @@
 'hist_QCD_Pt30To50_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1652471.5
+  cross-section: 1361000.0
   generated-events: 58236193.0
   group: GQCD
   yields-group: '9QCD'
@@ -372,7 +382,7 @@
 'hist_QCD_Pt50To80_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 437504.1
+  cross-section: 377800.0
   generated-events: 39479014.0
   group: GQCD
   yields-group: '9QCD'
@@ -381,7 +391,7 @@
 'hist_QCD_Pt80To120_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 106033.7
+  cross-section: 88620.0
   generated-events: 45269532.0
   group: GQCD
   yields-group: '9QCD'
@@ -390,7 +400,7 @@
 'hist_QCD_Pt120To170_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25190.5
+  cross-section: 21070.0
   generated-events: 39359230.0
   group: GQCD
   yields-group: '9QCD'
@@ -399,7 +409,7 @@
 'hist_QCD_Pt170To300_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 8654.5
+  cross-section: 7019.0
   generated-events: 72031492.0
   group: GQCD
   yields-group: '9QCD'
@@ -408,7 +418,7 @@
 'hist_QCD_Pt300To470_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 797.4
+  cross-section: 622.4
   generated-events: 58771417.0
   group: GQCD
   yields-group: '9QCD'
@@ -417,7 +427,7 @@
 'hist_QCD_Pt470To600_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 79.0
+  cross-section: 58.86
   generated-events: 38645779.0
   group: GQCD
   yields-group: '9QCD'
@@ -426,7 +436,7 @@
 'hist_QCD_Pt600To800_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 25.1
+  cross-section: 18.22
   generated-events: 38477713.0
   group: GQCD
   yields-group: '9QCD'
@@ -435,7 +445,7 @@
 'hist_QCD_Pt800To1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 4.7
+  cross-section: 3.25
   generated-events: 78922680.0
   group: GQCD
   yields-group: '9QCD'
@@ -444,7 +454,7 @@
 'hist_QCD_Pt1000_MuEnriched.root':
   type: mc
   pretty-name: 'QCD'
-  cross-section: 1.6
+  cross-section: 1.078
   generated-events: 27427195.0
   group: GQCD
   yields-group: '9QCD'

--- a/plotIt/configs/histos_control.yml
+++ b/plotIt/configs/histos_control.yml
@@ -2,351 +2,351 @@
 'h_ncleanjetspass_notausf_S1':
   log-y: true 
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanjetspass_S2':
   log-y: true 
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanjetspass_S3':
   log-y: true 
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanjetspass_S4':
   log-y: true 
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanjetspass_S5':
   log-y: true
   sort-by-yields: true
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #b jet multiplicities
 'h_ncleanbjetspass_notausf_S1':
   log-y: true
   sort-by-yields: true
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanbjetspass_S2':
   log-y: true
   sort-by-yields: true
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanbjetspass_S3':
   log-y: true
   sort-by-yields: true
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanbjetspass_S4':
   log-y: true
   sort-by-yields: true
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_ncleanbjetspass_S5':
   log-y: true
   sort-by-yields: true
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #PV
 'h_nvtx_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_nvtx_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_nvtx_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_nvtx_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_nvtx_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #MET pt
 'h_met_pt_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_met_pt_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_met_pt_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_met_pt_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_met_pt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 
 #MET phi
 'h_met_phi_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_met_phi_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_met_phi_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_met_phi_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_met_phi_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #Muon pt
 'h_muon1_pt_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [250, 599]
 
 'h_muon1_pt_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [250, 599]
 
 'h_muon1_pt_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [250, 599]
 
 'h_muon1_pt_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [250, 599]
 
 'h_muon1_pt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [250, 599]
 
 
 #Muon eta
 'h_muon1_eta_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_muon1_eta_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_muon1_eta_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_muon1_eta_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_muon1_eta_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #Muon + MET MT
 'h_muMET_mt_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_muMET_mt_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_muMET_mt_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_muMET_mt_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_muMET_mt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 
 #tau pt
 'h_tau1_pt_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_tau1_pt_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_tau1_pt_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 'h_tau1_pt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [200, 399]
 
 
 #tau eta
 'h_tau1_eta_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_tau1_eta_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_tau1_eta_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_tau1_eta_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #Muon tau dR
 'h_mutau_dR_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [0, 1.9]
 
 'h_mutau_dR_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [0, 1.9]
 
 'h_mutau_dR_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [0, 1.9]
 
 'h_mutau_dR_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [0, 1.9]
 
 
 #Muon tau mass
 'h_mutau_mass_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [400, 999]
 
 'h_mutau_mass_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [400, 999]
 
 'h_mutau_mass_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [400, 999]
 
 'h_mutau_mass_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [400, 999]
 
 
 #jet1 pt
 'h_jet1_pt_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 'h_jet1_pt_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 'h_jet1_pt_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 'h_jet1_pt_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 'h_jet1_pt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 
 #jet1 eta
 'h_jet1_eta_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_eta_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_eta_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_eta_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_eta_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #jet1 btag
 'h_jet1_btag_notausf_S1':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_btag_S2':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_btag_S3':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_btag_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet1_btag_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #jet2 pt
 'h_jet2_pt_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 'h_jet2_pt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 
 #jet2 eta
 'h_jet2_eta_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet2_eta_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #jet2 btag
 'h_jet2_btag_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet2_btag_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #jet3 pt
 'h_jet3_pt_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet3_pt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #jet3 eta
 'h_jet3_eta_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet3_eta_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #jet3 btag
 'h_jet3_btag_S4':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 'h_jet3_btag_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
 
 
 #bjet at step5
 'h_bjet1_pt_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [300, 399]
 
 'h_bjet1_eta_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']

--- a/plotIt/configs/histos_reco.yml
+++ b/plotIt/configs/histos_reco.yml
@@ -1,11 +1,11 @@
 'h_chi2_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [0, 40]
 
 'h_chi2_SMTop_mass_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [100, 240]
 
 'h_chi2_SMW_mass_S5':
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   blinded-range: [50, 130]

--- a/plotIt/configs/histos_yield.yml
+++ b/plotIt/configs/histos_yield.yml
@@ -3,7 +3,7 @@
   y-axis-format: "%1% / %2$.2f"
   signal-normalize-data: false
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   for-yields: true
   yields-table-order: 0
   yields-title: 'One muon'
@@ -14,7 +14,7 @@
   y-axis-format: "%1% / %2$.2f"
   signal-normalize-data: false
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   for-yields: true
   yields-table-order: 1
   yields-title: 'One tau'
@@ -25,7 +25,7 @@
   y-axis-format: "%1% / %2$.2f"
   signal-normalize-data: false
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   for-yields: true
   yields-table-order: 2
   yields-title: 'OS muon tau'
@@ -36,7 +36,7 @@
   y-axis-format: "%1% / %2$.2f"
   signal-normalize-data: false
   sort-by-yields: true 
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   for-yields: true
   yields-table-order: 3
   yields-title: 'nJets\geq 3'
@@ -47,7 +47,7 @@
   y-axis-format: "%1% / %2$.2f"
   signal-normalize-data: false
   sort-by-yields: true
-  save-extensions: ['pdf']
+  save-extensions: ['pdf', 'png']
   for-yields: true
   yields-table-order: 4
   yields-title: 'One b-tagged jet'

--- a/plotIt/configs/histos_yield.yml
+++ b/plotIt/configs/histos_yield.yml
@@ -39,7 +39,7 @@
   save-extensions: ['pdf', 'png']
   for-yields: true
   yields-table-order: 3
-  yields-title: 'nJets\geq 3'
+  yields-title: 'nJets$\geq$ 3'
   #post-fit: true
 
 'h_ncleanjetspass_yield_S5':

--- a/plotIt/include/types.h
+++ b/plotIt/include/types.h
@@ -421,6 +421,7 @@ namespace plotIt {
 
     // Systematics
     float luminosity_error_percent = 0;
+    bool syst_only = false;
 
     std::string y_axis_format = "%1% / %2$.2f";
     //std::string ratio_y_axis_title = "Data / MC";

--- a/plotIt/src/TH1Plotter.cc
+++ b/plotIt/src/TH1Plotter.cc
@@ -493,9 +493,9 @@ namespace plotIt {
 
     // Store all the histograms to draw, and find the one with the highest maximum
     std::vector<std::pair<TObject*, std::string>> toDraw = { std::make_pair(h_data.get(), data_drawing_options) };
-    for (File& signal: signal_files) {
-      toDraw.push_back(std::make_pair(signal.object, m_plotIt.getPlotStyle(signal)->drawing_options));
-    }
+    //for (File& signal: signal_files) {
+    //  toDraw.push_back(std::make_pair(signal.object, m_plotIt.getPlotStyle(signal)->drawing_options));
+    //}
 
     for (auto& mc_stack: mc_stacks) {
         toDraw.push_back(std::make_pair(mc_stack.second.stack.get(), ""));
@@ -610,7 +610,7 @@ namespace plotIt {
                 h_sig_temp->Scale(mc_stack_tmp.stat_only.get()->Integral()/h_sig_temp->Integral());
             }
             sigMax.push_back(h_sig_temp->GetMaximum());
-          }          
+          }
           max_sig = *std::max_element(sigMax.begin(), sigMax.end());
         }
         auto& mc_stack = mc_stacks.begin()->second;
@@ -630,10 +630,10 @@ namespace plotIt {
         else {
           if (plot.log_y) {
             maxfrac = 1000;
-            setMaximum(toDraw[0].first, max_sig + max_sig*maxfrac);
             minimum = 0.5;
           }
-          else setMaximum(toDraw[0].first, max_sig*1.5);
+          if (max_sig > max_data) setMaximum(toDraw[0].first, max_sig + max_sig*maxfrac);
+          else setMaximum(toDraw[0].first, max_data + max_data*maxfrac);
         }
       }
 
@@ -688,7 +688,6 @@ namespace plotIt {
       std::string options = m_plotIt.getPlotStyle(signal)->drawing_options + " same";
       if (plot.signal_normalize_data and !plot.no_data) {
         TH1* h_sig_temp = dynamic_cast<TH1*>(signal.object);
-        //h_sig_temp->Scale(h_data->Integral()/h_sig_temp->Integral());
         h_sig_temp->Scale(h_data_integral/h_sig_temp->Integral());
         h_sig_temp->Draw(options.c_str());
       }

--- a/plotIt/src/TH1Plotter.cc
+++ b/plotIt/src/TH1Plotter.cc
@@ -907,13 +907,17 @@ namespace plotIt {
 
           // relative error, delta X / X
           float syst = 0.;
+          const auto& config = m_plotIt.getConfiguration();
           if (plot.ratio_draw_mcstat_error or !plot.post_fit)
             syst = sqrt(pow(mc_stack.syst_only->GetBinError(i),2) + pow(mc_stack.stat_only->GetBinError(i),2)) / mc_stack.syst_only->GetBinContent(i);
-          else syst = mc_stack.syst_only->GetBinError(i) / mc_stack.syst_only->GetBinContent(i);
+          else if (config.syst_only) syst = mc_stack.syst_only->GetBinError(i) / mc_stack.syst_only->GetBinContent(i);
+          else syst = mc_stack.stat_and_syst->GetBinError(i) / mc_stack.syst_only->GetBinContent(i);
+
+          //std::cout << mc_stack.stat_and_syst->GetBinError(i) - mc_stack.syst_only->GetBinError(i) << std::endl;
 
           h_systematics->SetBinContent(i, 1);
-          //h_systematics->SetBinError(i, syst);
-          if (h_data.get()->GetBinContent(i) > 0) h_systematics->SetBinError(i, syst);
+          h_systematics->SetBinError(i, syst);
+          //if (h_data.get()->GetBinContent(i) > 0) h_systematics->SetBinError(i, syst);
 
           has_syst = true;
         }

--- a/plotIt/src/plotIt.cc
+++ b/plotIt/src/plotIt.cc
@@ -444,6 +444,9 @@ namespace plotIt {
       if (node["uncertainty-label"])
         m_config.uncertainty_label = node["uncertainty-label"].as<std::string>();
 
+      if (node["syst-only"])
+        m_config.syst_only = node["syst-only"].as<bool>();
+
       m_config.line_style.parse(node);
 
       if (node["labels"]) {


### PR DESCRIPTION
Wanted to store bSFs during skimming (it is better, considering its computing cost), but skimmed jets may contain taus. Thus, changed code to store per-jet SFs then calculate product of SFs during processing.

Also updated cross section values. PDFs are changed from old summary twiki page [1], thus need to update several numbers. Also ttbar and ST cross sections are being updated [2,3].

The WJets HT stitching is under investigation but added latest possible values. Those will be presented in GEN meeting and validated.

Finally, many RVec<Rvec<>> branches crash root prompt when trying to Scan, Draw, Show after a few events. But event loops using RDF and uproot are fine. I added small (and bare bones) script to print those (and any other) branches. I posted related question in root forum [4].

Included mc stat. unc. in the error band of ration plot as default. It was presented in the upper pad only. However, the stat. unc. are small 0.1 - 2%, and already negligible if we quadratically sum all systematic uncertainties (which are 2~10% order).

PlotIt bug fixed. In first step. y range is determined by comparing all histograms (data, mc stack, signals) using 'toDraw' vector. After that, we can adjust ranges. From the sorted vector, first item is drawn to draw axes. However, we apply additional scale to signal. Thus, if the first item is signal (eg, u mu tau tensor) and is scaled again, the range is changed. Simple solution is to remove signals from comparison. We do another comparison later in the code.

Remove duplicated xsec unc from plotit config (namely, ST_t and ST_tW. TTWJets and WJetsToLNu -> WJetsToLNu_HT)

[1] https://twiki.cern.ch/twiki/bin/viewauth/CMS/SummaryTable1G25ns
[2] https://twiki.cern.ch/twiki/bin/view/LHCPhysics/TtbarNNLO#Top_quark_pair_cross_sections_at
[3] https://twiki.cern.ch/twiki/bin/view/LHCPhysics/SingleTopRefXsec
[4] https://root-forum.cern.ch/t/reading-rvec-rvec-in-root-prompt/53255