### PR TITLE
for Nano v9 (ongoing PR)

### DIFF
--- a/nanoaodframe/ratioPlot.py
+++ b/nanoaodframe/ratioPlot.py
@@ -82,7 +82,8 @@ def AddSig(fname, name, color, xsection):
 AddBkg("hist_TTToSemiLeptonic.root", "TTLJ", '#990000', 365.34)
 AddBkg("hist_TTTo2L2Nu.root", "TTLL", '#330000', 88.29)
 AddBkg("hist_TTToHadronic.root", "TTHad", '#cc0000', 377.96)
-##ttH
+AddBkg("hist_ttHTobb.root", "ttV/H", '#ff66ff', 0.2934)
+AddBkg("hist_ttHToNonbb.root", "ttV/H", '#ff66ff', 0.2151)
 AddBkg("hist_TTWJetsToLNu.root", "ttV/H", '#ff66ff', 0.2043)
 AddBkg("hist_TTWJetsToQQ.root", "ttV/H", '#ff66ff', 0.4062)
 AddBkg("hist_TTZToLLNuNu.root", "ttV/H", '#ff66ff', 0.2529)
@@ -150,14 +151,12 @@ elif era == "2016post":
 
 elif era == "2017":
   SetData("hist_SingleMuon2017.root","data", 41480)
-  AddBkg("hist_ttHJetTobb.root", "ttV/H", '#ff66ff', 0.2934)
-  AddBkg("hist_ttHJetToNonbb.root", "ttV/H", '#ff66ff', 0.2151)
   AddSig("hist_ST_LFV_TCMuTau_Scalar.root", "STLFVc_s", '#99CC66', 0.00740)
-  #AddSig("hist_ST_LFV_TCMuTau_Vector.root", "STLFVc_v", '#99CC66', 0.0368)
+  AddSig("hist_ST_LFV_TCMuTau_Vector.root", "STLFVc_v", '#99CC66', 0.0368)
   AddSig("hist_ST_LFV_TCMuTau_Tensor.root", "STLFVc_t", '#99CC66', 0.1784)
-  #AddSig("hist_ST_LFV_TUMuTau_Scalar.root", "STLFVu_s", '#6B8551', 0.0838)
-  #AddSig("hist_ST_LFV_TUMuTau_Vector.root", "STLFVu_v", '#6B8551', 0.393)
-  #AddSig("hist_ST_LFV_TUMuTau_Tensor.root", "STLFVu_t", '#6B8551', 1.796)
+  AddSig("hist_ST_LFV_TUMuTau_Scalar.root", "STLFVu_s", '#6B8551', 0.0838)
+  AddSig("hist_ST_LFV_TUMuTau_Vector.root", "STLFVu_v", '#6B8551', 0.393)
+  AddSig("hist_ST_LFV_TUMuTau_Tensor.root", "STLFVu_t", '#6B8551', 1.796)
   AddSig("hist_TT_LFV_TCMuTau_Scalar.root", "TTLFVc_s", '#908DCC', 0.00269)
   AddSig("hist_TT_LFV_TCMuTau_Vector.root", "TTLFVc_v", '#908DCC', 0.0215)
   AddSig("hist_TT_LFV_TCMuTau_Tensor.root", "TTLFVc_t", '#908DCC', 0.1290)
@@ -168,17 +167,15 @@ elif era == "2017":
 
 elif era == "2018":
   SetData("hist_SingleMuon2018.root", "data", 59832)
-  AddBkg("hist_ttHJetTobb.root", "ttV/H", '#ff66ff', 0.2934)
-  AddBkg("hist_ttHJetToNonbb.root", "ttV/H", '#ff66ff', 0.2151)
   AddSig("hist_ST_LFV_TCMuTau_Scalar.root", "STLFVc_s", '#99CC66', 0.00740)
   AddSig("hist_ST_LFV_TCMuTau_Vector.root", "STLFVc_v", '#99CC66', 0.0368)
-  #AddSig("hist_ST_LFV_TCMuTau_Tensor.root", "STLFVc_t", '#99CC66', 0.1784)
+  AddSig("hist_ST_LFV_TCMuTau_Tensor.root", "STLFVc_t", '#99CC66', 0.1784)
   AddSig("hist_ST_LFV_TUMuTau_Scalar.root", "STLFVu_s", '#6B8551', 0.0838)
   AddSig("hist_ST_LFV_TUMuTau_Vector.root", "STLFVu_v", '#6B8551', 0.393)
-  #AddSig("hist_ST_LFV_TUMuTau_Tensor.root", "STLFVu_t", '#6B8551', 1.796)
+  AddSig("hist_ST_LFV_TUMuTau_Tensor.root", "STLFVu_t", '#6B8551', 1.796)
   AddSig("hist_TT_LFV_TCMuTau_Scalar.root", "TTLFVc_s", '#908DCC', 0.00269)
-  #AddSig("hist_TT_LFV_TCMuTau_Vector.root", "TTLFVc_v", '#908DCC', 0.0215)
-  #AddSig("hist_TT_LFV_TCMuTau_Tensor.root", "TTLFVc_t", '#908DCC', 0.1290)
+  AddSig("hist_TT_LFV_TCMuTau_Vector.root", "TTLFVc_v", '#908DCC', 0.0215)
+  AddSig("hist_TT_LFV_TCMuTau_Tensor.root", "TTLFVc_t", '#908DCC', 0.1290)
   AddSig("hist_TT_LFV_TUMuTau_Scalar.root", "TTLFVu_s", '#4F4D80', 0.00269)
   AddSig("hist_TT_LFV_TUMuTau_Vector.root", "TTLFVu_v", '#4F4D80', 0.0215)
   AddSig("hist_TT_LFV_TUMuTau_Tensor.root", "TTLFVu_t", '#4F4D80', 0.1290)
@@ -197,9 +194,9 @@ else:
 
 fNevt = open("Nevt_ratio.txt",'w')
 for fname in bkgsamples.keys():
-  fNevt.write(fname + " : generated events : " + str(bkgsamples[fname]["total"]) + "\n")
+  fNevt.write(fname + " : generated events : " + str(int(bkgsamples[fname]["total"])) + "\n")
 for fname in sigsamples.keys():
-  fNevt.write(fname + " : generated events : " + str(sigsamples[fname]["total"]) + "\n")
+  fNevt.write(fname + " : generated events : " + str(int (sigsamples[fname]["total"])) + "\n")
 
 count = 0
 for i in range(0, N_hist):

--- a/nanoaodframe/scripts/skim.py
+++ b/nanoaodframe/scripts/skim.py
@@ -18,7 +18,7 @@ os.makedirs(tgdir.replace('DATAMC', 'data'), exist_ok=True)
 os.makedirs(tgdir.replace('DATAMC', 'mc'), exist_ok=True)
 os.makedirs(log, exist_ok=True)
 
-for fn in os.listdir("data/dataset/v8UL_" + year):
+for fn in os.listdir("data/dataset/v9UL_" + year):
     if 'json' in fn: continue
     fname = fn.replace('dataset_', '').replace('.txt', '')
     test_list = options.dataset
@@ -30,7 +30,7 @@ for fn in os.listdir("data/dataset/v8UL_" + year):
         elif options.dataOrMC == 'mc':
             if '201' in fname: continue
 
-    with open(os.path.join("data/dataset/v8UL_" + year, fn), 'r') as f:
+    with open(os.path.join("data/dataset/v9UL_" + year, fn), 'r') as f:
         for line in f.readlines():
             if line.startswith('#'): continue
 

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -468,6 +468,7 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
             _jetCorrector->setJetA(jetAreas[i]);
             _jetCorrector->setRho(rho);
             float corrfactor = _jetCorrector->getCorrection();
+            if (abs(corrfactor) > 100.) corrfactor = 1.0;
             corrfactors.emplace_back(tocorrect[i] * rawfrac * corrfactor);
         }
         return corrfactors;
@@ -488,6 +489,7 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
                 corrector->setJetPt(jetpts[i]);
                 corrector->setJetEta(jetetas[i]);
                 float unc = corrector->getUncertainty(true);
+                if (abs(unc) > 100.) corrfactor = 0.;
                 uncSources.emplace_back(1.0f + unc);
                 uncSources.emplace_back(1.0f - unc);
             }
@@ -1224,6 +1226,8 @@ void NanoAODAnalyzerrdframe::topPtReweight() {
         else {
             float pt1 = toppt[0];
             float pt2 = toppt[1];
+            if (pt1 > 2000) pt1 = 1999;
+            if (pt2 > 2000) pt2 = 1999;
             int xbin1 = (std::upper_bound(xbins.begin(), xbins.end(), pt1)-1) - xbins.begin();
             int xbin2 = (std::upper_bound(xbins.begin(), xbins.end(), pt2)-1) - xbins.begin();
             out = std::sqrt( sfs.at(xbin1) * sfs.at(xbin2));

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -489,7 +489,7 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
                 corrector->setJetPt(jetpts[i]);
                 corrector->setJetEta(jetetas[i]);
                 float unc = corrector->getUncertainty(true);
-                if (abs(unc) > 100.) corrfactor = 0.;
+                if (abs(unc) > 100.) unc = 0.;
                 uncSources.emplace_back(1.0f + unc);
                 uncSources.emplace_back(1.0f - unc);
             }

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -499,7 +499,9 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
         return uncertainties;
     };
 
-    auto metCorr = [=](float met, float metphi, floats jetptsbefore, floats jetptsafter, floats jetphis, int npv, int runnb)->float {
+    auto metCorr = [=](float met, float metphi, floats jetptsbefore, floats jetptsafter, floats jetphis, int npv, unsigned int _runnb)->float {
+
+        int runnb = int(_runnb);
 
         auto metx = met * cos(metphi);
         auto mety = met * sin(metphi);
@@ -582,7 +584,9 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
         return corrfactors;
     };
 
-    auto metPhiCorr = [=](float met, float metphi, floats jetptsbefore, floats jetptsafter, floats jetphis, int npv, int runnb)->float {
+    auto metPhiCorr = [=](float met, float metphi, floats jetptsbefore, floats jetptsafter, floats jetphis, int npv, unsigned int _runnb)->float {
+
+        int runnb = int(_runnb);
 
         auto metx = met * cos(metphi);
         auto mety = met * sin(metphi);

--- a/nanoaodframe/src/SkimEvents.cpp
+++ b/nanoaodframe/src/SkimEvents.cpp
@@ -39,10 +39,10 @@ void SkimEvents::defineCuts()
 void SkimEvents::defineMoreVars()
 {
         if(_year.find("16") != std::string::npos){
-            addVar({"Flag_filter","Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && Flag_eeBadScFilter",""});
+            addVar({"Flag_filter","Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && Flag_BadPFMuonDzFilter && Flag_eeBadScFilter && Flag_hfNoisyHitsFilter",""});
         }else{
             // For 17, 18 UL
-            addVar({"Flag_filter","Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && Flag_eeBadScFilter && Flag_ecalBadCalibFilter",""});
+            addVar({"Flag_filter","Flag_goodVertices && Flag_globalSuperTightHalo2016Filter && Flag_HBHENoiseFilter && Flag_HBHENoiseIsoFilter && Flag_EcalDeadCellTriggerPrimitiveFilter && Flag_BadPFMuonFilter && Flag_BadPFMuonDzFilter && Flag_hfNoisyHitsFilter && Flag_eeBadScFilter && Flag_ecalBadCalibFilter",""});
         }
         // define variables that you want to store
         addVartoStore("run");
@@ -122,6 +122,7 @@ void SkimEvents::defineMoreVars()
         addVartoStore("nvetomuons");
         addVartoStore("muon4vecs");
         addVartoStore("fixedGridRhoFastjetAll");
+        addVartoStore("L1PreFiringWeight_.*");
 }
 
 void SkimEvents::bookHists()

--- a/plotIt/configs/files_2016post.yml
+++ b/plotIt/configs/files_2016post.yml
@@ -2,7 +2,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTcs'
 #  cross-section: 0.00740
-#  generated-events: 1580000.0
+#  generated-events: 1572000
 #  group: GLFVSTcs
 #  order: 1
 
@@ -10,7 +10,7 @@
   type: signal
   pretty-name: 'LFVSTcv'
   cross-section: 0.0368
-  generated-events: 1579000.0
+  generated-events: 1569000
   group: GLFVSTcv
   order: 1
 
@@ -18,7 +18,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTct'
 #  cross-section: 0.1784
-#  generated-events: 1578000.0
+#  generated-events: 1570000
 #  group: GLFVSTct
 #  order: 1
 #
@@ -26,7 +26,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTus'
 #  cross-section: 0.0838
-#  generated-events: 1578000.0
+#  generated-events: 1579000
 #  group: GLFVSTus
 #  order: 1
 
@@ -34,7 +34,7 @@
   type: signal
   pretty-name: 'LFVSTuv'
   cross-section: 0.393
-  generated-events: 1580000.0
+  generated-events: 1580000
   group: GLFVSTuv
   order: 2
 
@@ -42,7 +42,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTut'
 #  cross-section: 1.796
-#  generated-events: 1580000.0
+#  generated-events: 1573000
 #  group: GLFVSTut
 #  order: 1
 #
@@ -50,7 +50,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTcs'
 #  cross-section: 0.00269
-#  generated-events: 1580000.0
+#  generated-events: 1577000
 #  group: GLFVTTcs
 #  order: 1
 
@@ -58,7 +58,7 @@
   type: signal
   pretty-name: 'LFVTTcv'
   cross-section: 0.0215
-  generated-events: 1577000.0
+  generated-events: 1577000
   group: GLFVTTcv
   order: 3
 
@@ -66,7 +66,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTct'
 #  cross-section: 0.1290
-#  generated-events: 1580000.0
+#  generated-events: 1580000
 #  group: GLFVTTct
 #  order: 1
 #
@@ -74,7 +74,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTus'
 #  cross-section: 0.00269
-#  generated-events: 1580000.0
+#  generated-events: 1532000
 #  group: GLFVTTus
 #  order: 1
 
@@ -82,7 +82,7 @@
   type: signal
   pretty-name: 'LFVTTuv'
   cross-section: 0.0215
-  generated-events: 1580000.0
+  generated-events: 1562000
   group: GLFVTTuv
   order: 4
 
@@ -90,7 +90,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTut'
 #  cross-section: 0.1290
-#  generated-events: 1580000.0
+#  generated-events: 1580000
 #  group: GLFVTTut
 #  order: 1
 
@@ -103,7 +103,7 @@
   type: mc
   pretty-name: 'TTToSemiLeptonic'
   cross-section: 366.34
-  generated-events: 157314692.0
+  generated-events: 143553998
   group: Gttlj
   yields-group: '2\ttbar LJ'
   order: 6
@@ -112,7 +112,7 @@
   type: mc
   pretty-name: 'TTTo2L2Nu'
   cross-section: 88.51
-  generated-events: 47092114.0
+  generated-events: 43193956
   group: Gttll
   yields-group: '1\ttbar LL'
   order: 7
@@ -121,34 +121,34 @@
   type: mc
   pretty-name: 'TTToHadronic'
   cross-section: 379.05
-  generated-events: 111680750.0
+  generated-events: 106200414
   group: Gttjj
   yields-group: '3\ttbar Had'
   order: 8
 
-#'hist_ttHJetTobb.root':
-#  type: mc
-#  pretty-name: 'ttHTobb'
-#  cross-section: 0.2934
-#  generated-events: #FIXME
-#  group: GttV
-#  yields-group: '7tt+X'
-#  order: 9
-#
-#'hist_ttHJetToNonbb.root':
-#  type: mc
-#  pretty-name: 'ttHToNonbb'
-#  cross-section: 0.2151
-#  generated-events: #FIXME
-#  group: GttV
-#  yields-group: '7tt+X'
-#  order: 10
+'hist_ttHTobb.root':
+  type: mc
+  pretty-name: 'ttHTobb'
+  cross-section: 0.2934
+  generated-events: 4834712
+  group: GttV
+  yields-group: '7tt+X'
+  order: 9
+
+'hist_ttHToNonbb.root':
+  type: mc
+  pretty-name: 'ttHToNonbb'
+  cross-section: 0.2151
+  generated-events: 2194702
+  group: GttV
+  yields-group: '7tt+X'
+  order: 10
 
 'hist_TTWJetsToLNu.root':
   type: mc
   pretty-name: 'TTWJetsToLNu'
   cross-section: 0.2529
-  generated-events: 400706.0
+  generated-events: 1800823
   group: GttV
   yields-group: '7tt+X'
   order: 11
@@ -157,7 +157,7 @@
   type: mc
   pretty-name: 'TTWJetsToQQ'
   cross-section: 0.5297
-  generated-events: 168951.0
+  generated-events: 168951
   group: GttV
   yields-group: '7tt+X'
   order: 12
@@ -166,7 +166,7 @@
   type: mc
   pretty-name: 'TTZToLLNuNu'
   cross-section: 0.2529
-  generated-events: 3058448.0
+  generated-events: 2962856
   group: GttV
   yields-group: '7tt+X'
   order: 13
@@ -175,7 +175,7 @@
   type: mc
   pretty-name: 'TTZToQQ'
   cross-section: 0.5297
-  generated-events: 2879374.0
+  generated-events: 2682510
   group: GttV
   yields-group: '7tt+X'
   order: 14
@@ -184,7 +184,7 @@
   type: mc
   pretty-name: 'SingleTops'
   cross-section: 2.23
-  generated-events: 4085988.0
+  generated-events: 3562866
   group: GSingleT
   yields-group: '5Single Top'
   order: 15
@@ -193,7 +193,7 @@
   type: mc
   pretty-name: 'SingleTopt'
   cross-section: 134.2
-  generated-events: 58866028.0
+  generated-events: 59099222
   group: GSingleT
   yields-group: '5Single Top'
   order: 16
@@ -202,7 +202,7 @@
   type: mc
   pretty-name: 'SingleTbart'
   cross-section: 80.0
-  generated-events: 28677096.0
+  generated-events: 28814596
   group: GSingleT
   yields-group: '5Single Top'
   order: 17
@@ -211,7 +211,7 @@
   type: mc
   pretty-name: 'SingleToptW'
   cross-section: 39.65
-  generated-events: 2433862.0
+  generated-events: 2490860
   group: GSingleT
   yields-group: '5Single Top'
   order: 18
@@ -220,7 +220,7 @@
   type: mc
   pretty-name: 'SingleTbartW'
   cross-section: 39.65
-  generated-events: 2523884.0
+  generated-events: 2553882
   group: GSingleT
   yields-group: '5Single Top'
   order: 19
@@ -229,7 +229,7 @@
   type: mc
   pretty-name: 'WW'
   cross-section: 118.7
-  generated-events: 15907000.0
+  generated-events: 15821000
   group: GVV
   yields-group: '8VV'
   order: 20
@@ -238,7 +238,7 @@
   type: mc
   pretty-name: 'WZ'
   cross-section: 47.13
-  generated-events: 7768000.0
+  generated-events: 7584000
   group: GVV
   yields-group: '8VV'
   order: 21
@@ -247,7 +247,7 @@
   type: mc
   pretty-name: 'ZZ'
   cross-section: 16.91
-  generated-events: 1114000.0
+  generated-events: 1151000
   group: GVV
   yields-group: '8VV'
   order: 22
@@ -256,7 +256,7 @@
   type: mc
   pretty-name: 'DYJets10to50'
   cross-section: 18610
-  generated-events: 26927726.0
+  generated-events: 22388550
   group: GZJets
   yields-group: '4Z+Jets'
   order: 23
@@ -265,7 +265,7 @@
   type: mc
   pretty-name: 'DYJets'
   cross-section: 6077.22
-  generated-events: 64079563.0
+  generated-events: 48335328
   group: GZJets
   yields-group: '4Z+Jets'
   order: 24
@@ -274,7 +274,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
   cross-section: 65396.85 # 67350.0 * 0.972
-  generated-events: 85986988.0 # 88463979.0 * 0.972
+  generated-events: 78691397 # 80958227 * 0.972
   group: GWJets
   yields-group: '6W+Jets'
   order: 25
@@ -283,7 +283,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
   cross-section: 1519.76 # 1256.0 * 1.21
-  generated-events: 19616492.0
+  generated-events: 19753958
   group: GWJets
   yields-group: '6W+Jets'
   order: 26
@@ -292,7 +292,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
   cross-section: 406 # 335.5 * 1.21
-  generated-events: 16584072.0
+  generated-events: 15067621
   group: GWJets
   yields-group: '6W+Jets'
   order: 27
@@ -301,7 +301,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
   cross-section: 54.75 # 45.25 * 1.21
-  generated-events: 2237687.0
+  generated-events: 2115509
   group: GWJets
   yields-group: '6W+Jets'
   order: 28
@@ -310,7 +310,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
   cross-section: 14.58 # 12.05 * 1.21
-  generated-events: 2205351.0
+  generated-events: 2251807
   group: GWJets
   yields-group: '6W+Jets'
   order: 29
@@ -319,7 +319,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
   cross-section: 6.656 # 5.501 * 1.21
-  generated-events: 2190406.0
+  generated-events: 2132228
   group: GWJets
   yields-group: '6W+Jets'
   order: 30
@@ -328,7 +328,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
   cross-section: 1.404 # 1.16 * 1.21
-  generated-events: 2090561.0
+  generated-events: 2090561
   group: GWJets
   yields-group: '6W+Jets'
   order: 31
@@ -337,7 +337,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
   cross-section: 0.03146 # 0.026 * 1.21
-  generated-events: 677141.0
+  generated-events: 709514
   group: GWJets
   yields-group: '6W+Jets'
   order: 32
@@ -346,7 +346,7 @@
 #  type: mc
 #  pretty-name: 'QCD'
 #  cross-section: 2797000.0
-#  generated-events:
+#  generated-events: -
 #  group: GQCD
 #  yields-group: '9QCD'
 #  order: 33
@@ -355,7 +355,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 2518000.0
-  generated-events: 30255176.0
+  generated-events: 30853571
   group: GQCD
   yields-group: '9QCD'
   order: 34
@@ -364,7 +364,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1361000.0
-  generated-events: 35397812.0
+  generated-events: 35474172
   group: GQCD
   yields-group: '9QCD'
   order: 35
@@ -373,7 +373,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 377800.0
-  generated-events: 22279218.0
+  generated-events: 21491325
   group: GQCD
   yields-group: '9QCD'
   order: 36
@@ -382,7 +382,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 88620.0
-  generated-events: 23407998.0
+  generated-events: 22005632
   group: GQCD
   yields-group: '9QCD'
   order: 37
@@ -391,7 +391,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 21070.0
-  generated-events: 19763172.0
+  generated-events: 19772747
   group: GQCD
   yields-group: '9QCD'
   order: 38
@@ -400,7 +400,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 7019.0
-  generated-events: 36800197.0
+  generated-events: 34183334
   group: GQCD
   yields-group: '9QCD'
   order: 39
@@ -409,7 +409,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 622.4
-  generated-events: 30061697.0
+  generated-events: 29824712
   group: GQCD
   yields-group: '9QCD'
   order: 40
@@ -418,7 +418,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 58.86
-  generated-events: 20185257.0
+  generated-events: 19771458
   group: GQCD
   yields-group: '9QCD'
   order: 41
@@ -427,7 +427,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 18.22
-  generated-events: 19553333.0
+  generated-events: 18165741
   group: GQCD
   yields-group: '9QCD'
   order: 42
@@ -436,7 +436,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 3.25
-  generated-events: 41592873.0
+  generated-events: 38913226
   group: GQCD
   yields-group: '9QCD'
   order: 43
@@ -445,7 +445,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1.078
-  generated-events: 14243204.0
+  generated-events: 13905446
   group: GQCD
   yields-group: '9QCD'
   order: 44

--- a/plotIt/configs/files_2016pre.yml
+++ b/plotIt/configs/files_2016pre.yml
@@ -2,7 +2,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTcs'
 #  cross-section: 0.00740
-#  generated-events: 1388000.0
+#  generated-events: 1362000
 #  group: GLFVSTcs
 #  order: 1
 
@@ -10,7 +10,7 @@
   type: signal
   pretty-name: 'LFVSTcv'
   cross-section: 0.0368
-  generated-events: 1354000.0
+  generated-events: 1378000
   group: GLFVSTcv
   order: 1
 
@@ -18,7 +18,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTct'
 #  cross-section: 0.1784
-#  generated-events: 1370000.0
+#  generated-events: 1350000
 #  group: GLFVSTct
 #  order: 1
 #
@@ -26,7 +26,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTus'
 #  cross-section: 0.0838
-#  generated-events: 1350000.0
+#  generated-events: 1348000
 #  group: GLFVSTus
 #  order: 1
 
@@ -34,7 +34,7 @@
   type: signal
   pretty-name: 'LFVSTuv'
   cross-section: 0.393
-  generated-events: 1410000.0
+  generated-events: 1402000
   group: GLFVSTuv
   order: 2
 
@@ -42,7 +42,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTut'
 #  cross-section: 1.796
-#  generated-events: 1378000.0
+#  generated-events: 1382000
 #  group: GLFVSTut
 #  order: 1
 #
@@ -50,7 +50,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTcs'
 #  cross-section: 0.00269
-#  generated-events: 1316000.0
+#  generated-events: 1326000
 #  group: GLFVTTcs
 #  order: 1
 
@@ -58,7 +58,7 @@
   type: signal
   pretty-name: 'LFVTTcv'
   cross-section: 0.0215
-  generated-events: 1408000.0
+  generated-events: 1386000
   group: GLFVTTcv
   order: 3
 
@@ -66,7 +66,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTct'
 #  cross-section: 0.1290
-#  generated-events: 1358000.0
+#  generated-events: 1396000
 #  group: GLFVTTct
 #  order: 1
 #
@@ -74,7 +74,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTus'
 #  cross-section: 0.00269
-#  generated-events: 1208000.0
+#  generated-events: 1374000
 #  group: GLFVTTus
 #  order: 1
 
@@ -82,7 +82,7 @@
   type: signal
   pretty-name: 'LFVTTuv'
   cross-section: 0.0215
-  generated-events: 1406000.0
+  generated-events: 1410000
   group: GLFVTTuv
   order: 4
 
@@ -90,7 +90,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTut'
 #  cross-section: 0.1290
-#  generated-events: 1374000.0
+#  generated-events: 1352000
 #  group: GLFVTTut
 #  order: 1
 
@@ -103,7 +103,7 @@
   type: mc
   pretty-name: 'TTToSemiLeptonic'
   cross-section: 366.34
-  generated-events: 137049180.0
+  generated-events: 131106830
   group: Gttlj
   yields-group: '2\ttbar LJ'
   order: 6
@@ -112,7 +112,7 @@
   type: mc
   pretty-name: 'TTTo2L2Nu'
   cross-section: 88.51
-  generated-events: 41030018.0
+  generated-events: 37202074
   group: Gttll
   yields-group: '1\ttbar LL'
   order: 7
@@ -121,34 +121,34 @@
   type: mc
   pretty-name: 'TTToHadronic'
   cross-section: 379.05
-  generated-events: 97033134.0
+  generated-events: 96474574
   group: Gttjj
   yields-group: '3\ttbar Had'
   order: 8
 
-#'hist_ttHJetTobb.root':
-#  type: mc
-#  pretty-name: 'ttHTobb'
-#  cross-section: 0.2934
-#  generated-events: #FIXME
-#  group: GttV
-#  yields-group: '7tt+X'
-#  order: 9
-#
-#'hist_ttHJetToNonbb.root':
-#  type: mc
-#  pretty-name: 'ttHToNonbb'
-#  cross-section: 0.2151
-#  generated-events: #FIXME
-#  group: GttV
-#  yields-group: '7tt+X'
-#  order: 10
+'hist_ttHTobb.root':
+  type: mc
+  pretty-name: 'ttHTobb'
+  cross-section: 0.2934
+  generated-events: 4525710
+  group: GttV
+  yields-group: '7tt+X'
+  order: 9
+
+'hist_ttHToNonbb.root':
+  type: mc
+  pretty-name: 'ttHToNonbb'
+  cross-section: 0.2151
+  generated-events: 1936276
+  group: GttV
+  yields-group: '7tt+X'
+  order: 10
 
 'hist_TTWJetsToLNu.root':
   type: mc
   pretty-name: 'TTWJetsToLNu'
   cross-section: 0.2529
-  generated-events: 1555729.0
+  generated-events: 1543290
   group: GttV
   yields-group: '7tt+X'
   order: 11
@@ -157,7 +157,7 @@
   type: mc
   pretty-name: 'TTWJetsToQQ'
   cross-section: 0.5297
-  generated-events: 168842.0
+  generated-events: 148842
   group: GttV
   yields-group: '7tt+X'
   order: 12
@@ -166,7 +166,7 @@
   type: mc
   pretty-name: 'TTZToLLNuNu'
   cross-section: 0.2529
-  generated-events: 2848836.0
+  generated-events: 2856626
   group: GttV
   yields-group: '7tt+X'
   order: 13
@@ -175,7 +175,7 @@
   type: mc
   pretty-name: 'TTZToQQ'
   cross-section: 0.5297
-  generated-events: 3173716.0
+  generated-events: 3118292
   group: GttV
   yields-group: '7tt+X'
   order: 14
@@ -184,7 +184,7 @@
   type: mc
   pretty-name: 'SingleTops'
   cross-section: 2.23
-  generated-events: 3688762.0
+  generated-events: 3592772
   group: GSingleT
   yields-group: '5Single Top'
   order: 15
@@ -193,7 +193,7 @@
   type: mc
   pretty-name: 'SingleTopt'
   cross-section: 134.2
-  generated-events: 52437432.0
+  generated-events: 52437432
   group: GSingleT
   yields-group: '5Single Top'
   order: 16
@@ -202,7 +202,7 @@
   type: mc
   pretty-name: 'SingleTbart'
   cross-section: 80.0
-  generated-events: 29205918.0
+  generated-events: 29205918
   group: GSingleT
   yields-group: '5Single Top'
   order: 17
@@ -211,7 +211,7 @@
   type: mc
   pretty-name: 'SingleToptW'
   cross-section: 39.65
-  generated-events: 2299880.0
+  generated-events: 2299880
   group: GSingleT
   yields-group: '5Single Top'
   order: 18
@@ -220,7 +220,7 @@
   type: mc
   pretty-name: 'SingleTbartW'
   cross-section: 39.65
-  generated-events: 2299866.0
+  generated-events: 2299866
   group: GSingleT
   yields-group: '5Single Top'
   order: 19
@@ -229,7 +229,7 @@
   type: mc
   pretty-name: 'WW'
   cross-section: 118.7
-  generated-events: 15919000.0
+  generated-events: 15859000
   group: GVV
   yields-group: '8VV'
   order: 20
@@ -238,7 +238,7 @@
   type: mc
   pretty-name: 'WZ'
   cross-section: 47.13
-  generated-events: 7907000.0
+  generated-events: 7934000
   group: GVV
   yields-group: '8VV'
   order: 21
@@ -247,7 +247,7 @@
   type: mc
   pretty-name: 'ZZ'
   cross-section: 16.91
-  generated-events: 1270000.0
+  generated-events: 1282000
   group: GVV
   yields-group: '8VV'
   order: 22
@@ -256,7 +256,7 @@
   type: mc
   pretty-name: 'DYJets10to50'
   cross-section: 18610
-  generated-events: 32305345.0
+  generated-events: 25799525
   group: GZJets
   yields-group: '4Z+Jets'
   order: 23
@@ -265,7 +265,7 @@
   type: mc
   pretty-name: 'DYJets'
   cross-section: 6077.22
-  generated-events: 61893235.0
+  generated-events: 61192713
   group: GZJets
   yields-group: '4Z+Jets'
   order: 24
@@ -274,7 +274,7 @@
 #  type: mc
 #  pretty-name: 'WJetsToLNu_incl'
 #  cross-section: 67350.0
-#  generated-events: 75142187
+#  generated-events: 74686199
 #  group: GWJets
 #  yields-group: '6W+Jets'
 #  order: 25
@@ -283,7 +283,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
   cross-section: 65396.85 # 67350.0 * 0.972
-  generated-events: 73038206.0 # 75142187.0 * 0.972 (htcut)
+  generated-events: 72594985 # 74686199 * 0.972 (htcut)
   group: GWJets
   yields-group: '6W+Jets'
   order: 25
@@ -292,7 +292,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
   cross-section: 1519.76 # 1256.0 * 1.21
-  generated-events: 21756477.0
+  generated-events: 21734530
   group: GWJets
   yields-group: '6W+Jets'
   order: 26
@@ -301,7 +301,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
   cross-section: 406 # 335.5 * 1.21
-  generated-events: 227131.0
+  generated-events: 17870845
   group: GWJets
   yields-group: '6W+Jets'
   order: 27
@@ -310,7 +310,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
   cross-section: 54.75 # 45.25 * 1.21
-  generated-events: 2507514.0
+  generated-events: 2467498
   group: GWJets
   yields-group: '6W+Jets'
   order: 28
@@ -319,7 +319,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
   cross-section: 14.58 # 12.05 * 1.21
-  generated-events: 2402595.0
+  generated-events: 2344130
   group: GWJets
   yields-group: '6W+Jets'
   order: 29
@@ -328,7 +328,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
   cross-section: 6.656 # 5.501 * 1.21
-  generated-events: 2494564.0
+  generated-events: 2510487
   group: GWJets
   yields-group: '6W+Jets'
   order: 30
@@ -337,7 +337,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
   cross-section: 1.404 # 1.16 * 1.21
-  generated-events: 2119975.0
+  generated-events: 2119975
   group: GWJets
   yields-group: '6W+Jets'
   order: 31
@@ -346,7 +346,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
   cross-section: 0.03146 # 0.026 * 1.21
-  generated-events: 807531.0
+  generated-events: 808649
   group: GWJets
   yields-group: '6W+Jets'
   order: 32
@@ -354,7 +354,7 @@
 #'hist_QCD_Pt15To20_MuEnriched.root':
 #  type: mc
 #  pretty-name: 'QCD'
-#  cross-section: 2797000.0
+#  cross-section: -
 #  generated-events:
 #  group: GQCD
 #  yields-group: '9QCD'
@@ -364,7 +364,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 2518000.0
-  generated-events: 31521458.0
+  generated-events: 31926643
   group: GQCD
   yields-group: '9QCD'
   order: 34
@@ -373,7 +373,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1361000.0
-  generated-events: 28467772.0
+  generated-events: 28664840
   group: GQCD
   yields-group: '9QCD'
   order: 35
@@ -382,7 +382,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 377800.0
-  generated-events: 19668811.0
+  generated-events: 19724658
   group: GQCD
   yields-group: '9QCD'
   order: 36
@@ -391,7 +391,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 88620.0
-  generated-events: 22132145.0
+  generated-events: 21978558
   group: GQCD
   yields-group: '9QCD'
   order: 37
@@ -400,7 +400,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 21070.0
-  generated-events: 19239358.0
+  generated-events: 19136907
   group: GQCD
   yields-group: '9QCD'
   order: 38
@@ -409,7 +409,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 7019.0
-  generated-events: 36728058.0
+  generated-events: 37080544
   group: GQCD
   yields-group: '9QCD'
   order: 39
@@ -418,7 +418,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 622.4
-  generated-events: 29595276.0
+  generated-events: 28465385
   group: GQCD
   yields-group: '9QCD'
   order: 40
@@ -427,7 +427,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 58.86
-  generated-events: 20128914.0
+  generated-events: 19695298
   group: GQCD
   yields-group: '9QCD'
   order: 41
@@ -436,7 +436,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 18.22
-  generated-events: 19658498.0
+  generated-events: 19598815
   group: GQCD
   yields-group: '9QCD'
   order: 42
@@ -445,7 +445,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 3.25
-  generated-events: 39682082.0
+  generated-events: 38933940
   group: GQCD
   yields-group: '9QCD'
   order: 43
@@ -454,7 +454,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1.078
-  generated-events: 14189415.0
+  generated-events: 13660999
   group: GQCD
   yields-group: '9QCD'
   order: 44

--- a/plotIt/configs/files_2017.yml
+++ b/plotIt/configs/files_2017.yml
@@ -2,55 +2,55 @@
 #  type: signal
 #  pretty-name: 'LFVSTcs'
 #  cross-section: 0.00740
-#  generated-events: 3378000.0
+#  generated-events: 3244000
 #  group: GLFVSTcs
 #  order: 1
 
-#'hist_ST_LFV_TCMuTau_Vector.root':
-#  type: signal
-#  pretty-name: 'LFVSTcv'
-#  cross-section: 0.0368
-#  generated-events: #FIXME
-#  group: GLFVSTcv
-#  order: 1
-
-'hist_ST_LFV_TCMuTau_Tensor.root':
+'hist_ST_LFV_TCMuTau_Vector.root':
   type: signal
-  pretty-name: 'LFVSTct'
-  cross-section: 0.1784
-  generated-events: 3404000.0
-  group: GLFVSTct
+  pretty-name: 'LFVSTcv'
+  cross-section: 0.0368
+  generated-events: 3500000
+  group: GLFVSTcv
   order: 1
+
+#'hist_ST_LFV_TCMuTau_Tensor.root':
+#  type: signal
+#  pretty-name: 'LFVSTct'
+#  cross-section: 0.1784
+#  generated-events: 3374000
+#  group: GLFVSTct
+#  order: 1
 
 #'hist_ST_LFV_TUMuTau_Scalar.root':
 #  type: signal
 #  pretty-name: 'LFVSTus'
 #  cross-section: 0.0838
-#  generated-events: #FIXME
+#  generated-events: 3450000
 #  group: GLFVSTus
 #  order: 1
 
-#'hist_ST_LFV_TUMuTau_Vector.root':
-#  type: signal
-#  pretty-name: 'LFVSTuv'
-#  cross-section: 0.393
-#  generated-events: #FIXME
-#  group: GLFVSTuv
-#  order: 2
-
-'hist_ST_LFV_TUMuTau_Tensor.root':
+'hist_ST_LFV_TUMuTau_Vector.root':
   type: signal
-  pretty-name: 'LFVSTut'
-  cross-section: 1.796
-  generated-events: 3478000.0
-  group: GLFVSTut
-  order: 1
+  pretty-name: 'LFVSTuv'
+  cross-section: 0.393
+  generated-events: 3407000
+  group: GLFVSTuv
+  order: 2
+
+#'hist_ST_LFV_TUMuTau_Tensor.root':
+#  type: signal
+#  pretty-name: 'LFVSTut'
+#  cross-section: 1.796
+#  generated-events: 3498000
+#  group: GLFVSTut
+#  order: 1
 
 #'hist_TT_LFV_TCMuTau_Scalar.root':
 #  type: signal
 #  pretty-name: 'LFVTTcs'
 #  cross-section: 0.00269
-#  generated-events: 3101000.0 
+#  generated-events: 3424000
 #  group: GLFVTTcs
 #  order: 1
 
@@ -58,7 +58,7 @@
   type: signal
   pretty-name: 'LFVTTcv'
   cross-section: 0.0215
-  generated-events: 3370000.0
+  generated-events: 3376000
   group: GLFVTTcv
   order: 3
 
@@ -66,7 +66,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTct'
 #  cross-section: 0.1290
-#  generated-events: 3448000.0
+#  generated-events: 3401000
 #  group: GLFVTTct
 #  order: 1
 #
@@ -74,7 +74,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTus'
 #  cross-section: 0.00269
-#  generated-events: 3346600.0
+#  generated-events: 3344000
 #  group: GLFVTTus
 #  order: 1
 
@@ -82,7 +82,7 @@
   type: signal
   pretty-name: 'LFVTTuv'
   cross-section: 0.0215
-  generated-events: 3458000.0
+  generated-events: 3434000
   group: GLFVTTuv
   order: 4
 
@@ -90,7 +90,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTut'
 #  cross-section: 0.1290
-#  generated-events: 3394000.0
+#  generated-events: 3286000
 #  group: GLFVTTut
 #  order: 1
 
@@ -103,7 +103,7 @@
   type: mc
   pretty-name: 'TTToSemiLeptonic'
   cross-section: 366.34
-  generated-events: 355826000.0
+  generated-events: 343257666
   group: Gttlj
   yields-group: '2\ttbar LJ'
   order: 6
@@ -112,7 +112,7 @@
   type: mc
   pretty-name: 'TTTo2L2Nu'
   cross-section: 88.51
-  generated-events: 106978000.0
+  generated-events: 105859990
   group: Gttll
   yields-group: '1\ttbar LL'
   order: 7
@@ -121,25 +121,25 @@
   type: mc
   pretty-name: 'TTToHadronic'
   cross-section: 379.05
-  generated-events: 246712999.0
+  generated-events: 231117295
   group: Gttjj
   yields-group: '3\ttbar Had'
   order: 8
 
-'hist_ttHJetTobb.root':
+'hist_ttHTobb.root':
   type: mc
   pretty-name: 'ttHTobb'
   cross-section: 0.2934
-  generated-events: 11590377
+  generated-events: 7661778
   group: GttV
   yields-group: '7tt+X'
   order: 9
 
-'hist_ttHJetToNonbb.root':
+'hist_ttHToNonbb.root':
   type: mc
   pretty-name: 'ttHToNonbb'
   cross-section: 0.2151
-  generated-events: 7368333
+  generated-events: 4965389
   group: GttV
   yields-group: '7tt+X'
   order: 10
@@ -148,7 +148,7 @@
   type: mc
   pretty-name: 'TTWJetsToLNu'
   cross-section: 0.2529
-  generated-events: 7464889.0
+  generated-events: 3871055
   group: GttV
   yields-group: '7tt+X'
   order: 11
@@ -157,7 +157,7 @@
   type: mc
   pretty-name: 'TTWJetsToQQ'
   cross-section: 0.5297
-  generated-events: 688849.0
+  generated-events: 359006
   group: GttV
   yields-group: '7tt+X'
   order: 12
@@ -166,7 +166,7 @@
   type: mc
   pretty-name: 'TTZToLLNuNu'
   cross-section: 0.2529
-  generated-events: 14196000.0
+  generated-events: 6911466
   group: GttV
   yields-group: '7tt+X'
   order: 13
@@ -175,7 +175,7 @@
   type: mc
   pretty-name: 'TTZToQQ'
   cross-section: 0.5297
-  generated-events: 14154000.0
+  generated-events: 6865808
   group: GttV
   yields-group: '7tt+X'
   order: 14
@@ -184,7 +184,7 @@
   type: mc
   pretty-name: 'SingleTops'
   cross-section: 2.23
-  generated-events: 12447484
+  generated-events: 8866570
   group: GSingleT
   yields-group: '5Single Top'
   order: 15
@@ -193,7 +193,7 @@
   type: mc
   pretty-name: 'SingleTopt'
   cross-section: 134.2
-  generated-events: 126808000.0
+  generated-events: 121728252
   group: GSingleT
   yields-group: '5Single Top'
   order: 16
@@ -202,7 +202,7 @@
   type: mc
   pretty-name: 'SingleTbart'
   cross-section: 80.0
-  generated-events: 69189000.0
+  generated-events: 65701154
   group: GSingleT
   yields-group: '5Single Top'
   order: 17
@@ -211,7 +211,7 @@
   type: mc
   pretty-name: 'SingleToptW'
   cross-section: 39.65
-  generated-events: 5669000.0
+  generated-events: 5648712
   group: GSingleT
   yields-group: '5Single Top'
   order: 18
@@ -220,7 +220,7 @@
   type: mc
   pretty-name: 'SingleTbartW'
   cross-section: 39.65
-  generated-events: 5518000.0
+  generated-events: 5673700
   group: GSingleT
   yields-group: '5Single Top'
   order: 19
@@ -229,7 +229,7 @@
   type: mc
   pretty-name: 'WW'
   cross-section: 118.7
-  generated-events: 15883000.0
+  generated-events: 15634000
   group: GVV
   yields-group: '8VV'
   order: 20
@@ -238,7 +238,7 @@
   type: mc
   pretty-name: 'WZ'
   cross-section: 47.13
-  generated-events: 7898000.0
+  generated-events: 7889000
   group: GVV
   yields-group: '8VV'
   order: 21
@@ -247,7 +247,7 @@
   type: mc
   pretty-name: 'ZZ'
   cross-section: 16.91
-  generated-events: 2708000.0
+  generated-events: 2706000
   group: GVV
   yields-group: '8VV'
   order: 22
@@ -256,7 +256,7 @@
   type: mc
   pretty-name: 'DYJets10to50'
   cross-section: 18610
-  generated-events: 68072143.0
+  generated-events: 68480179
   group: GZJets
   yields-group: '4Z+Jets'
   order: 23
@@ -265,7 +265,7 @@
   type: mc
   pretty-name: 'DYJets'
   cross-section: 6077.22
-  generated-events: 194627557.0
+  generated-events: 131552424
   group: GZJets
   yields-group: '4Z+Jets'
   order: 24
@@ -274,7 +274,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
   cross-section: 65396.85 # 67350.0 * 0.972
-  generated-events: 78979334.0 # 81254459 * 0.972
+  generated-events: 76114585 # 78307186 * 0.972
   group: GWJets
   yields-group: '6W+Jets'
   order: 25
@@ -283,7 +283,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
   cross-section: 1519.76 # 1256.0 * 1.21
-  generated-events: 47691676.0
+  generated-events: 47424468
   group: GWJets
   yields-group: '6W+Jets'
   order: 26
@@ -292,7 +292,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
   cross-section: 406 # 335.5 * 1.21
-  generated-events: 42400350.0
+  generated-events: 42281979
   group: GWJets
   yields-group: '6W+Jets'
   order: 27
@@ -301,7 +301,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
   cross-section: 54.75 # 45.25 * 1.21
-  generated-events: 5470704.0
+  generated-events: 5468473
   group: GWJets
   yields-group: '6W+Jets'
   order: 28
@@ -310,7 +310,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
   cross-section: 14.58 # 12.05 * 1.21
-  generated-events: 5484477.0
+  generated-events: 5545298
   group: GWJets
   yields-group: '6W+Jets'
   order: 29
@@ -319,7 +319,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
   cross-section: 6.656 # 5.501 * 1.21
-  generated-events: 5389834.0
+  generated-events: 5088483
   group: GWJets
   yields-group: '6W+Jets'
   order: 30
@@ -328,7 +328,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
   cross-section: 1.404 # 1.16 * 1.21
-  generated-events: 4935967.0
+  generated-events: 4752118
   group: GWJets
   yields-group: '6W+Jets'
   order: 31
@@ -337,7 +337,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
   cross-section: 0.03146 # 0.026 * 1.21
-  generated-events: 1185699.0
+  generated-events: 1185699
   group: GWJets
   yields-group: '6W+Jets'
   order: 32
@@ -346,7 +346,7 @@
 #  type: mc
 #  pretty-name: 'QCD'
 #  cross-section: 2797000.0
-#  generated-events: 8989902.0
+#  generated-events: -
 #  group: GQCD
 #  yields-group: '9QCD'
 #  order: 33
@@ -355,7 +355,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 2518000.0
-  generated-events: 63651596.0
+  generated-events: 64623134
   group: GQCD
   yields-group: '9QCD'
   order: 34
@@ -364,7 +364,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1361000.0
-  generated-events: 58595659.0
+  generated-events: 58639613
   group: GQCD
   yields-group: '9QCD'
   order: 35
@@ -373,7 +373,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 377800.0
-  generated-events: 40002811.0
+  generated-events: 40322726
   group: GQCD
   yields-group: '9QCD'
   order: 36
@@ -382,7 +382,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 88620.0
-  generated-events: 45587818.0
+  generated-events: 45981017
   group: GQCD
   yields-group: '9QCD'
   order: 37
@@ -391,7 +391,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 21070.0
-  generated-events: 39406203.0
+  generated-events: 39394151
   group: GQCD
   yields-group: '9QCD'
   order: 38
@@ -400,7 +400,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 7019.0
-  generated-events: 73066072.0
+  generated-events: 73071987
   group: GQCD
   yields-group: '9QCD'
   order: 39
@@ -409,7 +409,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 622.4
-  generated-events: 58597948.0
+  generated-events: 58692910
   group: GQCD
   yields-group: '9QCD'
   order: 40
@@ -418,7 +418,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 58.86
-  generated-events: 39816804.0
+  generated-events: 39491752
   group: GQCD
   yields-group: '9QCD'
   order: 41
@@ -427,7 +427,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 18.22
-  generated-events: 39326156.0
+  generated-events: 39321940
   group: GQCD
   yields-group: '9QCD'
   order: 42
@@ -436,7 +436,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 3.25
-  generated-events: 78171998.0
+  generated-events: 78215559
   group: GQCD
   yields-group: '9QCD'
   order: 43
@@ -445,7 +445,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1.078
-  generated-events: 27537497.0
+  generated-events: 27478273
   group: GQCD
   yields-group: '9QCD'
   order: 44

--- a/plotIt/configs/files_2018.yml
+++ b/plotIt/configs/files_2018.yml
@@ -2,7 +2,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTcs'
 #  cross-section: 0.00740
-#  generated-events: 4822000.0
+#  generated-events: 4815000
 #  group: GLFVSTcs
 #  order: 1
 
@@ -10,7 +10,7 @@
   type: signal
   pretty-name: 'LFVSTcv'
   cross-section: 0.0368
-  generated-events: 4856000.0
+  generated-events: 4832000
   group: GLFVSTcv
   order: 1
 
@@ -18,7 +18,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTct'
 #  cross-section: 0.1784
-#  generated-events: FIXME
+#  generated-events: 4878240
 #  group: GLFVSTct
 #  order: 1
 #
@@ -26,7 +26,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTus'
 #  cross-section: 0.0838
-#  generated-events: 4807000.0
+#  generated-events: 4759000
 #  group: GLFVSTus
 #  order: 1
 
@@ -34,7 +34,7 @@
   type: signal
   pretty-name: 'LFVSTuv'
   cross-section: 0.393
-  generated-events: 4897981.0
+  generated-events: 4787609
   group: GLFVSTuv
   order: 2
 
@@ -42,7 +42,7 @@
 #  type: signal
 #  pretty-name: 'LFVSTut'
 #  cross-section: 1.796
-#  generated-events: FIXME
+#  generated-events: 4900000
 #  group: GLFVSTut
 #  order: 1
 #
@@ -50,7 +50,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTcs'
 #  cross-section: 0.00269
-#  generated-events: 4786000.0
+#  generated-events: 4745000
 #  group: GLFVTTcs
 #  order: 1
 
@@ -58,7 +58,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTcv'
 #  cross-section: 0.0215
-#  generated-events: #FIXME
+#  generated-events: 4894624
 #  group: GLFVTTcv
 #  order: 3
 
@@ -66,7 +66,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTct'
 #  cross-section: 0.1290
-#  generated-events: FIXME
+#  generated-events: 4838000
 #  group: GLFVTTct
 #  order: 1
 #
@@ -74,7 +74,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTus'
 #  cross-section: 0.00269
-#  generated-events: 4804000.0
+#  generated-events: 4848000
 #  group: GLFVTTus
 #  order: 1
 
@@ -82,7 +82,7 @@
   type: signal
   pretty-name: 'LFVTTuv'
   cross-section: 0.0215
-  generated-events: 4842000.0
+  generated-events: 4816000
   group: GLFVTTuv
   order: 4
 
@@ -90,7 +90,7 @@
 #  type: signal
 #  pretty-name: 'LFVTTut'
 #  cross-section: 0.1290
-#  generated-events: 4716000.0
+#  generated-events: 4642000
 #  group: GLFVTTut
 #  order: 1
 
@@ -103,7 +103,7 @@
   type: mc
   pretty-name: 'TTToSemiLeptonic'
   cross-section: 366.34
-  generated-events: 482836098.0
+  generated-events: 472557630
   group: Gttlj
   yields-group: '2\ttbar LJ'
   order: 6
@@ -112,7 +112,7 @@
   type: mc
   pretty-name: 'TTTo2L2Nu'
   cross-section: 88.51
-  generated-events: 147271052.0
+  generated-events: 143848848
   group: Gttll
   yields-group: '1\ttbar LL'
   order: 7
@@ -121,25 +121,25 @@
   type: mc
   pretty-name: 'TTToHadronic'
   cross-section: 379.05
-  generated-events: 337254908.0
+  generated-events: 331506194
   group: Gttjj
   yields-group: '3\ttbar Had'
   order: 8
 
-'hist_ttHJetTobb.root':
+'hist_ttHTobb.root':
   type: mc
   pretty-name: 'ttHTobb'
   cross-section: 0.2934
-  generated-events: 3258053.0
+  generated-events: 9467226
   group: GttV
   yields-group: '7tt+X'
   order: 9
 
-'hist_ttHJetToNonbb.root':
+'hist_ttHToNonbb.root':
   type: mc
   pretty-name: 'ttHToNonbb'
   cross-section: 0.2151
-  generated-events: 3283863.0
+  generated-events: 7176599
   group: GttV
   yields-group: '7tt+X'
   order: 10
@@ -148,7 +148,7 @@
   type: mc
   pretty-name: 'TTWJetsToLNu'
   cross-section: 0.2529
-  generated-events: 5706163.0
+  generated-events: 5666428
   group: GttV
   yields-group: '7tt+X'
   order: 11
@@ -157,7 +157,7 @@
   type: mc
   pretty-name: 'TTWJetsToQQ'
   cross-section: 0.5297
-  generated-events: 530327.0
+  generated-events: 530327
   group: GttV
   yields-group: '7tt+X'
   order: 12
@@ -166,7 +166,7 @@
   type: mc
   pretty-name: 'TTZToLLNuNu'
   cross-section: 0.2529
-  generated-events: 9840572.0
+  generated-events: 9651834
   group: GttV
   yields-group: '7tt+X'
   order: 13
@@ -175,7 +175,7 @@
   type: mc
   pretty-name: 'TTZToQQ'
   cross-section: 0.5297
-  generated-events: 9925946.0
+  generated-events: 9854220
   group: GttV
   yields-group: '7tt+X'
   order: 14
@@ -184,7 +184,7 @@
   type: mc
   pretty-name: 'SingleTops'
   cross-section: 2.23
-  generated-events: 12993045.0
+  generated-events: 12607741
   group: GSingleT
   yields-group: '5Single Top'
   order: 15
@@ -193,7 +193,7 @@
   type: mc
   pretty-name: 'SingleTopt'
   cross-section: 134.2
-  generated-events: 165365582.0
+  generated-events: 167111718
   group: GSingleT
   yields-group: '5Single Top'
   order: 16
@@ -202,7 +202,7 @@
   type: mc
   pretty-name: 'SingleTbart'
   cross-section: 80.0
-  generated-events: 89304382.0
+  generated-events: 90022642
   group: GSingleT
   yields-group: '5Single Top'
   order: 17
@@ -211,7 +211,7 @@
   type: mc
   pretty-name: 'SingleToptW'
   cross-section: 39.65
-  generated-events: 5978718.0
+  generated-events: 7955614
   group: GSingleT
   yields-group: '5Single Top'
   order: 18
@@ -220,7 +220,7 @@
   type: mc
   pretty-name: 'SingleTbartW'
   cross-section: 39.65
-  generated-events: 5779768.0
+  generated-events: 7748690
   group: GSingleT
   yields-group: '5Single Top'
   order: 19
@@ -229,7 +229,7 @@
   type: mc
   pretty-name: 'WW'
   cross-section: 118.7
-  generated-events: 15670000.0
+  generated-events: 15679000
   group: GVV
   yields-group: '8VV'
   order: 20
@@ -238,7 +238,7 @@
   type: mc
   pretty-name: 'WZ'
   cross-section: 47.13
-  generated-events: 7986000.0
+  generated-events: 7940000
   group: GVV
   yields-group: '8VV'
   order: 21
@@ -247,7 +247,7 @@
   type: mc
   pretty-name: 'ZZ'
   cross-section: 16.91
-  generated-events: 3907000.0
+  generated-events: 3526000
   group: GVV
   yields-group: '8VV'
   order: 22
@@ -256,7 +256,7 @@
   type: mc
   pretty-name: 'DYJets10to50'
   cross-section: 18610
-  generated-events: 99449093.0
+  generated-events: 94452816
   group: GZJets
   yields-group: '4Z+Jets'
   order: 23
@@ -265,7 +265,7 @@
   type: mc
   pretty-name: 'DYJets'
   cross-section: 6077.22
-  generated-events: 131927642.0
+  generated-events: 131572454
   group: GZJets
   yields-group: '4Z+Jets'
   order: 24
@@ -274,7 +274,7 @@
 #  type: mc
 #  pretty-name: 'WJetsToLNu_incl'
 #  cross-section: 67350.0
-#  generated-events: 83009353
+#  generated-events: 81051269
 #  group: GWJets
 #  yields-group: '6W+Jets'
 #  order: 25
@@ -283,7 +283,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT0To100'
   cross-section: 65396.85 # 67350.0 * 0.972
-  generated-events: 80685091.0 # 83009353 * 0.972 (htcut)
+  generated-events: 78781833 # 81051269 * 0.972 (htcut)
   group: GWJets
   yields-group: '6W+Jets'
   order: 25
@@ -293,7 +293,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT100To200'
   cross-section: 1519.76 # 1256.0 * 1.21
-  generated-events: 66195407.0
+  generated-events: 51408967
   group: GWJets
   yields-group: '6W+Jets'
   order: 26
@@ -302,7 +302,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT200To400'
   cross-section: 406 # 335.5 * 1.21
-  generated-events: 56898682.0
+  generated-events: 58225632
   group: GWJets
   yields-group: '6W+Jets'
   order: 27
@@ -311,7 +311,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT400To600'
   cross-section: 54.75 # 45.25 * 1.21
-  generated-events: 7545618.0
+  generated-events: 7444030
   group: GWJets
   yields-group: '6W+Jets'
   order: 28
@@ -320,7 +320,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT600To800'
   cross-section: 14.58 # 12.05 * 1.21
-  generated-events: 7556181.0
+  generated-events: 7718765
   group: GWJets
   yields-group: '6W+Jets'
   order: 29
@@ -329,7 +329,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT800To1200'
   cross-section: 6.656 # 5.501 * 1.21
-  generated-events: 7418726.0
+  generated-events: 7306187
   group: GWJets
   yields-group: '6W+Jets'
   order: 30
@@ -338,7 +338,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT1200To2500'
   cross-section: 1.404 # 1.16 * 1.21
-  generated-events: 6855219.0
+  generated-events: 6481518
   group: GWJets
   yields-group: '6W+Jets'
   order: 31
@@ -347,7 +347,7 @@
   type: mc
   pretty-name: 'WJetsToLNu_HT2500ToInf'
   cross-section: 0.03146 # 0.026 * 1.21
-  generated-events: 2097648.0
+  generated-events: 2097648
   group: GWJets
   yields-group: '6W+Jets'
   order: 32
@@ -356,7 +356,7 @@
 #  type: mc
 #  pretty-name: 'QCD'
 #  cross-section: 2797000.0
-#  generated-events:
+#  generated-events: -
 #  group: GQCD
 #  yields-group: '9QCD'
 #  order: 33
@@ -365,7 +365,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 2518000.0
-  generated-events: 60662268.0
+  generated-events: 60640516
   group: GQCD
   yields-group: '9QCD'
   order: 34
@@ -374,7 +374,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1361000.0
-  generated-events: 58236193.0
+  generated-events: 58737695
   group: GQCD
   yields-group: '9QCD'
   order: 35
@@ -383,7 +383,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 377800.0
-  generated-events: 39479014.0
+  generated-events: 40022458
   group: GQCD
   yields-group: '9QCD'
   order: 36
@@ -392,7 +392,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 88620.0
-  generated-events: 45269532.0
+  generated-events: 45494357
   group: GQCD
   yields-group: '9QCD'
   order: 37
@@ -401,7 +401,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 21070.0
-  generated-events: 39359230.0
+  generated-events: 38022194
   group: GQCD
   yields-group: '9QCD'
   order: 38
@@ -410,7 +410,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 7019.0
-  generated-events: 72031492.0
+  generated-events: 71870974
   group: GQCD
   yields-group: '9QCD'
   order: 39
@@ -419,7 +419,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 622.4
-  generated-events: 58771417.0
+  generated-events: 58949756
   group: GQCD
   yields-group: '9QCD'
   order: 40
@@ -428,7 +428,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 58.86
-  generated-events: 38645779.0
+  generated-events: 38453296
   group: GQCD
   yields-group: '9QCD'
   order: 41
@@ -437,7 +437,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 18.22
-  generated-events: 38477713.0
+  generated-events: 37197942
   group: GQCD
   yields-group: '9QCD'
   order: 42
@@ -446,7 +446,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 3.25
-  generated-events: 78922680.0
+  generated-events: 78942993
   group: GQCD
   yields-group: '9QCD'
   order: 43
@@ -455,7 +455,7 @@
   type: mc
   pretty-name: 'QCD'
   cross-section: 1.078
-  generated-events: 27427195.0
+  generated-events: 27427130
   group: GQCD
   yields-group: '9QCD'
   order: 44


### PR DESCRIPTION
- plot config update (file*yml) for nano v9
- Update MET filters
- 'ratioPlot.py' update (missing samples are now available. This script is useful to print yields quickly / or to get gen events at once)
- store prefire weights to use in processing
- store prefire weight (already nom/vars are in nanoaod)
- update top pt reweight part (PT safe if-statement is required). Set pt to 1999 if pt > 2000
- JES overflow? if absolute value is greater than 100, return 1.0 (corr factor) or 0.0 (unc).
- skim.py -> dataset location from v8 to v9
- 
To do
- Apply prefire weight in processing.

REF to MET filters: https://twiki.cern.ch/twiki/bin/viewauth/CMS/MissingETOptionalFiltersRun2