### PR TITLE
Hem

### DIFF
--- a/nanoaodframe/print_syst_table.py
+++ b/nanoaodframe/print_syst_table.py
@@ -30,6 +30,7 @@ unc_cat = OrderedDict([
          'scale', 'ps', 'pdf',
          'py8tune', 'hdamp',]),
 ('pu', ['pu']),
+('prefire', ['prefire']),
 ('xsec', ['xsec']),
 ('muon', ['muid', 'muiso', 'mutrg']),
 ('tauid', ['tauidjet', 'tauidel', 'tauidmu']),
@@ -60,11 +61,6 @@ unc_cat = OrderedDict([
 ('bAll', ['btaghf', 'btaglf', 'btaghfstats1', 'btaglfstats1',
           'btaghfstats2', 'btaglfstats2', 'btagcferr1', 'btagcferr2']),
 ])
-
-#FIXME don't forget this
-#if year == "2017":
-#  unc_cat['prefire'] = ['prefire']
-#  unc_cat['all'].append('prefire')
 
 #Create syst yaml everytime, to avoid crash due to different treatments
 with open(config_path + "config_" + year + ".yml") as f:

--- a/nanoaodframe/scripts/process.py
+++ b/nanoaodframe/scripts/process.py
@@ -32,6 +32,8 @@ syst_list = ["", "__tesup", "__tesdown", "__jerup","__jerdown", "__jesAbsoluteup
              "__jesBBEC1up", "__jesBBEC1down", "__jesBBEC1_"+year[:4]+"up", "__jesBBEC1_"+year[:4]+"down",
              "__jesFlavorQCDup", "__jesFlavorQCDdown", "__jesRelativeBalup", "__jesRelativeBaldown",
              "__jesRelativeSample_"+year[:4]+"up", "__jesRelativeSample_"+year[:4]+"down"]
+if year == "2018": syst_list.append("__jesHEM")
+
 # tune and hdamp will appear as an individual dataset.
 # thus no need to run in loop, but left here for double check
 syst_ext = ["__tuneup", "__tunedown", "__hdampup", "__hdampdown",]

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -513,53 +513,53 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
             }
         }
 
-	//starting phi modulation correction on met 
-	// https://lathomas.web.cern.ch/lathomas/METStuff/XYCorrections/XYMETCorrection_withUL17andUL18andUL16.h
+        //starting phi modulation correction on met
+        // https://lathomas.web.cern.ch/lathomas/METStuff/XYCorrections/XYMETCorrection_withUL17andUL18andUL16.h
 
-	auto uncormet = float(sqrt(metx*metx + mety*mety));
-	auto uncormet_phi = float(atan2(mety, metx));
+        auto uncormet = float(sqrt(metx*metx + mety*mety));
+        auto uncormet_phi = float(atan2(mety, metx));
 
-	if(npv>100) npv=100;
-	auto METxcorr(0.),METycorr(0.);
-	if (!_isData) {
-	//UL2016
-	if(_isRun16pre) METxcorr = -(-0.153497*npv +-0.231751);
-	if(_isRun16pre) METycorr = -(0.00731978*npv +0.243323);
-	if(_isRun16post) METxcorr = -(-0.188743*npv +0.136539);
-	if(_isRun16post) METycorr = -(0.0127927*npv +0.117747);	
-	//UL2017
-	if(_isRun17) METxcorr = -(-0.300155*npv +1.90608);
-	if(_isRun17) METycorr = -(0.300213*npv +-2.02232);
-	//UL2018
-	if(_isRun18) METxcorr = -(0.183518*npv +0.546754);
-	if(_isRun18) METycorr = -(0.192263*npv +-0.42121);
-	}
-	if (_isData) {
-	//UL2018
-	if(runnb >=315252 && runnb <=316995 ) {METxcorr = -(0.263733*npv +-1.91115);METycorr = -(0.0431304*npv +-0.112043);}
-	if(runnb >=316998 && runnb <=319312 ) {METxcorr = -(0.400466*npv +-3.05914);METycorr = -(0.146125*npv +-0.533233);}
-	if(runnb >=319313 && runnb <=320393 ) {METxcorr = -(0.430911*npv +-1.42865);METycorr = -(0.0620083*npv +-1.46021);}
-	if(runnb >=320394 && runnb <=325273 ) {METxcorr = -(0.457327*npv +-1.56856);METycorr = -(0.0684071*npv +-0.928372);}
-	//UL2017
-	if(runnb >=297020 && runnb <=299329 ) {METxcorr = -(-0.211161*npv +0.419333);METycorr = -(0.251789*npv +-1.28089);}
-	if(runnb >=299337 && runnb <=302029 ) {METxcorr = -(-0.185184*npv +-0.164009);METycorr = -(0.200941*npv +-0.56853);}
-	if(runnb >=302030 && runnb <=303434 ) {METxcorr = -(-0.201606*npv +0.426502);METycorr = -(0.188208*npv +-0.58313);}
-	if(runnb >=303435 && runnb <=304826 ) {METxcorr = -(-0.162472*npv +0.176329);METycorr = -(0.138076*npv +-0.250239);}
-	if(runnb >=304911 && runnb <=306462 ) {METxcorr = -(-0.210639*npv +0.72934);METycorr = -(0.198626*npv +1.028);}
-	//UL2016
-	if(runnb >=272007 && runnb <=275376 ) {METxcorr = -(-0.0214894*npv +-0.188255);METycorr = -(0.0876624*npv +0.812885);}
-	if(runnb >=275657 && runnb <=276283 ) {METxcorr = -(-0.032209*npv +0.067288);METycorr = -(0.113917*npv +0.743906);}
-	if(runnb >=276315 && runnb <=276811 ) {METxcorr = -(-0.0293663*npv +0.21106);METycorr = -(0.11331*npv +0.815787);}
-	if(runnb >=276831 && runnb <=277420 ) {METxcorr = -(-0.0132046*npv +0.20073);METycorr = -(0.134809*npv +0.679068);}
-	if(((runnb >=277772 && runnb <=278768) || runnb==278770)) {METxcorr = -(-0.0543566*npv +0.816597);METycorr = -(0.114225*npv +1.17266);};
-	if(((runnb >=278801 && runnb <=278808) || runnb==278769)) {METxcorr = -(0.134616*npv +-0.89965);METycorr = -(0.0397736*npv +1.0385);};
-	if(runnb >=278820 && runnb <=280385 ) {METxcorr = -(0.121809*npv +-0.584893);METycorr = -(0.0558974*npv +0.891234);};
-	if(runnb >=280919 && runnb <=284044 ) {METxcorr = -(0.0868828*npv +-0.703489);METycorr = -(0.0888774*npv +0.902632);};
+        if(npv>100) npv=100;
+        auto METxcorr(0.),METycorr(0.);
+        if (!_isData) {
+            //UL2016
+            if(_isRun16pre) METxcorr = -(-0.153497 * npv + -0.231751);
+            if(_isRun16pre) METycorr = -(0.00731978 * npv + 0.243323);
+            if(_isRun16post) METxcorr = -(-0.188743 * npv + 0.136539);
+            if(_isRun16post) METycorr = -(0.0127927 * npv + 0.117747);
+            //UL2017
+            if(_isRun17) METxcorr = -(-0.300155 * npv + 1.90608);
+            if(_isRun17) METycorr = -(0.300213 * npv + -2.02232);
+            //UL2018
+            if(_isRun18) METxcorr = -(0.183518 * npv + 0.546754);
+            if(_isRun18) METycorr = -(0.192263 * npv + -0.42121);
         }
-	auto CorrectedMET_x = uncormet *cos( uncormet_phi)+METxcorr;
-	auto CorrectedMET_y = uncormet *sin( uncormet_phi)+METycorr;
+        if (_isData) {
+            //UL2018
+            if(runnb >= 315252 && runnb <= 316995 ) {METxcorr = -(0.263733 * npv + -1.91115); METycorr = -(0.0431304 * npv + -0.112043);}
+            if(runnb >= 316998 && runnb <= 319312 ) {METxcorr = -(0.400466 * npv + -3.05914); METycorr = -(0.146125 * npv + -0.533233);}
+            if(runnb >= 319313 && runnb <= 320393 ) {METxcorr = -(0.430911 * npv + -1.42865); METycorr = -(0.0620083 * npv + -1.46021);}
+            if(runnb >= 320394 && runnb <= 325273 ) {METxcorr = -(0.457327 * npv + -1.56856); METycorr = -(0.0684071 * npv + -0.928372);}
+            //UL2017
+            if(runnb >= 297020 && runnb <= 299329 ) {METxcorr = -(-0.211161 * npv + 0.419333); METycorr = -(0.251789 * npv + -1.28089);}
+            if(runnb >= 299337 && runnb <= 302029 ) {METxcorr = -(-0.185184 * npv + -0.164009); METycorr = -(0.200941 * npv + -0.56853);}
+            if(runnb >= 302030 && runnb <= 303434 ) {METxcorr = -(-0.201606 * npv + 0.426502); METycorr = -(0.188208 * npv + -0.58313);}
+            if(runnb >= 303435 && runnb <= 304826 ) {METxcorr = -(-0.162472 * npv + 0.176329); METycorr = -(0.138076 * npv + -0.250239);}
+            if(runnb >= 304911 && runnb <= 306462 ) {METxcorr = -(-0.210639 * npv + 0.72934); METycorr = -(0.198626 * npv + 1.028);}
+            //UL2016
+            if(runnb >= 272007 && runnb <= 275376 ) {METxcorr = -(-0.0214894 * npv + -0.188255); METycorr = -(0.0876624 * npv + 0.812885);}
+            if(runnb >= 275657 && runnb <= 276283 ) {METxcorr = -(-0.032209 * npv + 0.067288); METycorr = -(0.113917 * npv + 0.743906);}
+            if(runnb >= 276315 && runnb <= 276811 ) {METxcorr = -(-0.0293663 * npv + 0.21106); METycorr = -(0.11331 * npv + 0.815787);}
+            if(runnb >= 276831 && runnb <= 277420 ) {METxcorr = -(-0.0132046 * npv + 0.20073); METycorr = -(0.134809 * npv + 0.679068);}
+            if(((runnb >= 277772 && runnb <= 278768) || runnb==278770)) {METxcorr = -(-0.0543566 * npv + 0.816597); METycorr = -(0.114225 * npv + 1.17266);};
+            if(((runnb >= 278801 && runnb <= 278808) || runnb==278769)) {METxcorr = -(0.134616 * npv + -0.89965); METycorr = -(0.0397736 * npv + 1.0385);};
+            if(runnb >= 278820 && runnb <= 280385 ) {METxcorr = -(0.121809 * npv + -0.584893); METycorr = -(0.0558974 * npv + 0.891234);};
+            if(runnb >= 280919 && runnb <= 284044 ) {METxcorr = -(0.0868828 * npv + -0.703489); METycorr = -(0.0888774 * npv + 0.902632);};
+        }
+        auto CorrectedMET_x = uncormet * cos( uncormet_phi ) + METxcorr;
+        auto CorrectedMET_y = uncormet * sin( uncormet_phi ) + METycorr;
 
-	float CorrectedMET = sqrt(CorrectedMET_x*CorrectedMET_x+CorrectedMET_y*CorrectedMET_y);
+        float CorrectedMET = sqrt(CorrectedMET_x * CorrectedMET_x + CorrectedMET_y * CorrectedMET_y);
 
         return CorrectedMET;
     };
@@ -597,61 +597,63 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
                 mety -= (jetptsafter[i] - jetptsbefore[i])*sin(jetphis[i]);
             }
         }
-	//starting phi modulation correction on met phi 
-	// https://lathomas.web.cern.ch/lathomas/METStuff/XYCorrections/XYMETCorrection_withUL17andUL18andUL16.h
 
-	auto uncormet = float(sqrt(metx*metx + mety*mety));
-	auto uncormet_phi = float(atan2(mety, metx));
+        //starting phi modulation correction on met phi
+        // https://lathomas.web.cern.ch/lathomas/METStuff/XYCorrections/XYMETCorrection_withUL17andUL18andUL16.h
 
-	if(npv>100) npv=100;
-	auto METxcorr(0.),METycorr(0.);
-	if (!_isData) {
-	//UL2016
-	if(_isRun16pre) METxcorr = -(-0.153497*npv +-0.231751);
-	if(_isRun16pre) METycorr = -(0.00731978*npv +0.243323);
-	if(_isRun16post) METxcorr = -(-0.188743*npv +0.136539);
-	if(_isRun16post) METycorr = -(0.0127927*npv +0.117747);	
-	//UL2017
-	if(_isRun17) METxcorr = -(-0.300155*npv +1.90608);
-	if(_isRun17) METycorr = -(0.300213*npv +-2.02232);
-	//UL2018
-	if(_isRun18) METxcorr = -(0.183518*npv +0.546754);
-	if(_isRun18) METycorr = -(0.192263*npv +-0.42121);
-	}
-	if (_isData) {
-	//UL2018
-	if(runnb >=315252 && runnb <=316995 ) {METxcorr = -(0.263733*npv +-1.91115);METycorr = -(0.0431304*npv +-0.112043);}
-	if(runnb >=316998 && runnb <=319312 ) {METxcorr = -(0.400466*npv +-3.05914);METycorr = -(0.146125*npv +-0.533233);}
-	if(runnb >=319313 && runnb <=320393 ) {METxcorr = -(0.430911*npv +-1.42865);METycorr = -(0.0620083*npv +-1.46021);}
-	if(runnb >=320394 && runnb <=325273 ) {METxcorr = -(0.457327*npv +-1.56856);METycorr = -(0.0684071*npv +-0.928372);}
-	//UL2017
-	if(runnb >=297020 && runnb <=299329 ) {METxcorr = -(-0.211161*npv +0.419333);METycorr = -(0.251789*npv +-1.28089);}
-	if(runnb >=299337 && runnb <=302029 ) {METxcorr = -(-0.185184*npv +-0.164009);METycorr = -(0.200941*npv +-0.56853);}
-	if(runnb >=302030 && runnb <=303434 ) {METxcorr = -(-0.201606*npv +0.426502);METycorr = -(0.188208*npv +-0.58313);}
-	if(runnb >=303435 && runnb <=304826 ) {METxcorr = -(-0.162472*npv +0.176329);METycorr = -(0.138076*npv +-0.250239);}
-	if(runnb >=304911 && runnb <=306462 ) {METxcorr = -(-0.210639*npv +0.72934);METycorr = -(0.198626*npv +1.028);}
-	//UL2016
-	if(runnb >=272007 && runnb <=275376 ) {METxcorr = -(-0.0214894*npv +-0.188255);METycorr = -(0.0876624*npv +0.812885);}
-	if(runnb >=275657 && runnb <=276283 ) {METxcorr = -(-0.032209*npv +0.067288);METycorr = -(0.113917*npv +0.743906);}
-	if(runnb >=276315 && runnb <=276811 ) {METxcorr = -(-0.0293663*npv +0.21106);METycorr = -(0.11331*npv +0.815787);}
-	if(runnb >=276831 && runnb <=277420 ) {METxcorr = -(-0.0132046*npv +0.20073);METycorr = -(0.134809*npv +0.679068);}
-	if(((runnb >=277772 && runnb <=278768) || runnb==278770)) {METxcorr = -(-0.0543566*npv +0.816597);METycorr = -(0.114225*npv +1.17266);};
-	if(((runnb >=278801 && runnb <=278808) || runnb==278769)) {METxcorr = -(0.134616*npv +-0.89965);METycorr = -(0.0397736*npv +1.0385);};
-	if(runnb >=278820 && runnb <=280385 ) {METxcorr = -(0.121809*npv +-0.584893);METycorr = -(0.0558974*npv +0.891234);};
-	if(runnb >=280919 && runnb <=284044 ) {METxcorr = -(0.0868828*npv +-0.703489);METycorr = -(0.0888774*npv +0.902632);};
+        auto uncormet = float(sqrt(metx*metx + mety*mety));
+        auto uncormet_phi = float(atan2(mety, metx));
+
+        if(npv>100) npv=100;
+        auto METxcorr(0.),METycorr(0.);
+
+        if (!_isData) {
+            //UL2016
+            if (_isRun16pre) METxcorr = -(-0.153497 * npv + -0.231751);
+            if (_isRun16pre) METycorr = -(0.00731978 * npv + 0.243323);
+            if (_isRun16post) METxcorr = -(-0.188743 * npv + 0.136539);
+            if (_isRun16post) METycorr = -(0.0127927 * npv + 0.117747);
+            //UL2017
+            if (_isRun17) METxcorr = -(-0.300155 * npv + 1.90608);
+            if (_isRun17) METycorr = -(0.300213 * npv + -2.02232);
+            //UL2018
+            if (_isRun18) METxcorr = -(0.183518 * npv + 0.546754);
+            if (_isRun18) METycorr = -(0.192263 * npv + -0.42121);
+        }
+        if (_isData) {
+            //UL2018
+            if (runnb >= 315252 && runnb <= 316995 ) {METxcorr = -(0.263733 * npv + -1.91115); METycorr = -(0.0431304 * npv + -0.112043);}
+            if (runnb >= 316998 && runnb <= 319312 ) {METxcorr = -(0.400466 * npv + -3.05914); METycorr = -(0.146125 * npv + -0.533233);}
+            if (runnb >= 319313 && runnb <= 320393 ) {METxcorr = -(0.430911 * npv + -1.42865); METycorr = -(0.0620083 * npv + -1.46021);}
+            if (runnb >= 320394 && runnb <= 325273 ) {METxcorr = -(0.457327 * npv + -1.56856); METycorr = -(0.0684071 * npv + -0.928372);}
+            //UL2017
+            if (runnb >= 297020 && runnb <= 299329 ) {METxcorr = -(-0.211161 * npv + 0.419333); METycorr = -(0.251789 * npv + -1.28089);}
+            if (runnb >= 299337 && runnb <= 302029 ) {METxcorr = -(-0.185184 * npv + -0.164009); METycorr = -(0.200941 * npv + -0.56853);}
+            if (runnb >= 302030 && runnb <= 303434 ) {METxcorr = -(-0.201606 * npv + 0.426502); METycorr = -(0.188208 * npv + -0.58313);}
+            if (runnb >= 303435 && runnb <= 304826 ) {METxcorr = -(-0.162472 * npv + 0.176329); METycorr = -(0.138076 * npv + -0.250239);}
+            if (runnb >= 304911 && runnb <= 306462 ) {METxcorr = -(-0.210639 * npv + 0.72934); METycorr = -(0.198626 * npv + 1.028);}
+            //UL2016
+            if (runnb >= 272007 && runnb <= 275376 ) {METxcorr = -(-0.0214894 * npv + -0.188255); METycorr = -(0.0876624 * npv + 0.812885);}
+            if (runnb >= 275657 && runnb <= 276283 ) {METxcorr = -(-0.032209 * npv + 0.067288); METycorr = -(0.113917 * npv + 0.743906);}
+            if (runnb >= 276315 && runnb <= 276811 ) {METxcorr = -(-0.0293663 * npv + 0.21106); METycorr = -(0.11331 * npv + 0.815787);}
+            if (runnb >= 276831 && runnb <= 277420 ) {METxcorr = -(-0.0132046 * npv + 0.20073); METycorr = -(0.134809 * npv + 0.679068);}
+            if (((runnb >= 277772 && runnb <= 278768) || runnb==278770)) {METxcorr = -(-0.0543566 * npv + 0.816597); METycorr = -(0.114225 * npv + 1.17266);};
+            if (((runnb >= 278801 && runnb <= 278808) || runnb==278769)) {METxcorr = -(0.134616 * npv + -0.89965); METycorr = -(0.0397736 * npv + 1.0385);};
+            if (runnb >= 278820 && runnb <= 280385 ) {METxcorr = -(0.121809 * npv + -0.584893); METycorr = -(0.0558974 * npv + 0.891234);};
+            if (runnb >= 280919 && runnb <= 284044 ) {METxcorr = -(0.0868828 * npv + -0.703489); METycorr = -(0.0888774 * npv + 0.902632);};
         }
 
-	auto CorrectedMET_x = uncormet *cos( uncormet_phi)+METxcorr;
-	auto CorrectedMET_y = uncormet *sin( uncormet_phi)+METycorr;
+        auto CorrectedMET_x = uncormet * cos( uncormet_phi ) + METxcorr;
+        auto CorrectedMET_y = uncormet * sin( uncormet_phi ) + METycorr;
 
         float CorrectedMETPhi;
 
-        if(CorrectedMET_x==0 && CorrectedMET_y>0) CorrectedMETPhi = TMath::Pi();
-        else if(CorrectedMET_x==0 && CorrectedMET_y<0 )CorrectedMETPhi = -TMath::Pi();
-        else if(CorrectedMET_x >0) CorrectedMETPhi = TMath::ATan(CorrectedMET_y/CorrectedMET_x);
-        else if(CorrectedMET_x <0&& CorrectedMET_y>0) CorrectedMETPhi = TMath::ATan(CorrectedMET_y/CorrectedMET_x) + TMath::Pi();
-        else if(CorrectedMET_x <0&& CorrectedMET_y<0) CorrectedMETPhi = TMath::ATan(CorrectedMET_y/CorrectedMET_x) - TMath::Pi();
-        else CorrectedMETPhi =0;
+        if      (CorrectedMET_x==0 && CorrectedMET_y>0) CorrectedMETPhi = TMath::Pi();
+        else if (CorrectedMET_x==0 && CorrectedMET_y<0 ) CorrectedMETPhi = -TMath::Pi();
+        else if (CorrectedMET_x >0) CorrectedMETPhi = TMath::ATan(CorrectedMET_y / CorrectedMET_x);
+        else if (CorrectedMET_x <0 && CorrectedMET_y>0) CorrectedMETPhi = TMath::ATan(CorrectedMET_y / CorrectedMET_x) + TMath::Pi();
+        else if (CorrectedMET_x <0 && CorrectedMET_y<0) CorrectedMETPhi = TMath::ATan(CorrectedMET_y / CorrectedMET_x) - TMath::Pi();
+        else    CorrectedMETPhi =0;
 
         return CorrectedMETPhi;
     };

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.h
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.h
@@ -111,7 +111,8 @@ private:
   inline static std::vector<std::string> jes_var_2018 = {"jesAbsoluteup", "jesAbsolutedown",
                 "jesAbsolute_2018up", "jesAbsolute_2018down", "jesBBEC1up", "jesBBEC1down",
                 "jesBBEC1_2018up", "jesBBEC1_2018down", "jesFlavorQCDup", "jesFlavorQCDdown",
-                "jesRelativeBalup", "jesRelativeBaldown", "jesRelativeSample_2018up", "jesRelativeSample_2018down"};
+                "jesRelativeBalup", "jesRelativeBaldown", "jesRelativeSample_2018up", "jesRelativeSample_2018down",
+                "jesHEM"};
   floats PDFWeights;
   std::string _jsonfname;
   std::string _globaltag;

--- a/nanoaodframe/src/TopLFVAnalyzer.cpp
+++ b/nanoaodframe/src/TopLFVAnalyzer.cpp
@@ -166,6 +166,9 @@ void TopLFVAnalyzer::defineMoreVars() {
             } else if (_syst.find("jesRelativeSample_" + _year.substr(0,4) + "down") != std::string::npos) {
                 addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB_jes[13]"});
                 addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB_jes[13]"});
+            } else if (_syst.find("jesHEM") != std::string::npos && _year == "2018") { //HEM
+                addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB_jes[0]"});
+                addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB_jes[0]"});
             } else {
                 addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB[0]"});
                 addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB[0]"});


### PR DESCRIPTION
HEM is included as a jes var "jesHEM", only for 2018.
If one run process.py with -S all option, all histogram with HEM application [1] (namely, jes is set to 0.8 for the jet fall into the eta-phi region) will be generated.

In addition, indentations for met x-y correction are fixed.

[1] https://hypernews.cern.ch/HyperNews/CMS/get/JetMET/2000.html