### PR TITLE
hem bug fix, up and down files

### DIFF
--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -450,6 +450,7 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
             cout<<"Applying JEC Uncertainty"<<endl;
             for (std::string src : jes_var) {
                 if (src.find("up") != std::string::npos) {
+                    if (src.find("HEM") != std::string::npos) continue;
                     auto uncsource = src.substr(3, src.size()-2-3);
                     cout << "JEC Uncertainty Source : " + uncsource << endl;
                     string dbfilenameunc = basedirectory + "RegroupedV2_" + _globaltag + "_MC_UncertaintySources_AK4PFchs.txt";
@@ -505,8 +506,9 @@ void NanoAODAnalyzerrdframe::setupJetMETCorrection(string globaltag, std::vector
             if (_year == "2018") {
                 if (jetphis[i] > -1.57 && jetphis[i] < -0.87 && jetetas[i] > -2.5 && jetetas[i] < -1.3) {
                     uncSources.emplace_back(0.8);
-                } else {
                     uncSources.emplace_back(1.0);
+                } else {
+                    uncSources.insert(uncSources.end(), 2, 1.0);
                 }
             }
             uncertainties.emplace_back(uncSources);
@@ -853,7 +855,10 @@ void NanoAODAnalyzerrdframe::applyBSFs(std::vector<string> jes_var) {
     cout << "Loading Btag SF" << endl;
     string btagpath = "data/btagSF/";
 
-    if (_year == "2018") jes_var.erase(std::remove(jes_var.begin(), jes_var.end(), "jesHEM"), jes_var.end());
+    if (_year == "2018") {
+        jes_var.erase(std::remove(jes_var.begin(), jes_var.end(), "jesHEMup"), jes_var.end());
+        jes_var.erase(std::remove(jes_var.begin(), jes_var.end(), "jesHEMdown"), jes_var.end());
+    }
 
     BTagCalibration _btagcalib = {"DeepJet", btagpath + "skimmed_btag_" + _year + ".csv"};
     cout << "    Loaded file : " << btagpath + "skimmed_btag_" + _year + ".csv" << endl;

--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.h
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.h
@@ -112,7 +112,7 @@ private:
                 "jesAbsolute_2018up", "jesAbsolute_2018down", "jesBBEC1up", "jesBBEC1down",
                 "jesBBEC1_2018up", "jesBBEC1_2018down", "jesFlavorQCDup", "jesFlavorQCDdown",
                 "jesRelativeBalup", "jesRelativeBaldown", "jesRelativeSample_2018up", "jesRelativeSample_2018down",
-                "jesHEM"};
+                "jesHEMup", "jesHEMdown"};
   floats PDFWeights;
   std::string _jsonfname;
   std::string _globaltag;

--- a/nanoaodframe/src/TopLFVAnalyzer.cpp
+++ b/nanoaodframe/src/TopLFVAnalyzer.cpp
@@ -170,9 +170,12 @@ void TopLFVAnalyzer::defineMoreVars() {
             } else if (_syst.find("jesRelativeSample_" + _year.substr(0,4) + "down") != std::string::npos) {
                 addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB_jes[13]"});
                 addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB_jes[13]"});
-            } else if (_syst.find("jesHEM") != std::string::npos && _year == "2018") { //HEM
-                addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB_jes[0]"});
-                addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB_jes[0]"});
+            } else if (_syst.find("jesHEMup") != std::string::npos && _year == "2018") { //HEM
+                addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB[0]"});
+                addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB[0]"});
+            } else if (_syst.find("jesHEMdown") != std::string::npos && _year == "2018") { //HEM down - dummy
+                addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB[0]"});
+                addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB[0]"});
             } else {
                 addVar({"eventWeight", "eventWeight_nobtag * btagWeight_DeepFlavB[0]"});
                 addVar({"eventWeight_notau", "eventWeight_genpumu * btagWeight_DeepFlavB[0]"});


### PR DESCRIPTION
This one needs discussion (short!)

I wanted to produce HEM shapes in the consistent was as the other JES soures.
Thus jesHEMup is set to HEM-varied shape, jesHEMdown is just nominal one.
One more copy of JES variation will not take too much time for processing, once skimmed.

Also fixed a bug that wrong bSF for HEM is used. This should not be a critical issue.