### PR TITLE
update top and w boson mass and width in chi2 method

### DIFF
--- a/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
+++ b/nanoaodframe/src/NanoAODAnalyzerrdframe.cpp
@@ -225,6 +225,7 @@ void NanoAODAnalyzerrdframe::setupAnalysis() {
         selectJets(jes_var);
         if (!_isData){
             topPtReweight();
+            //matchGenReco();
         }
     }
     defineMoreVars();
@@ -1236,7 +1237,10 @@ void NanoAODAnalyzerrdframe::selectTaus() {
 }
 
 void NanoAODAnalyzerrdframe::matchGenReco() {
-
+    cout << "match Gen Reco" << endl;
+    cout << "columns: " <<endl;
+    for (const auto& name: _rlm.GetColumnNames()) cout << name << ", ";
+    cout << endl;
     _rlm = _rlm.Define("FinalGenPart_idx", ::FinalGenPart_idx, {"GenPart_pdgId", "GenPart_genPartIdxMother"})
                .Define("GenPart_LFVup_idx", "FinalGenPart_idx[0]")
                .Define("GenPart_LFVmuon_idx", "FinalGenPart_idx[1]")
@@ -1249,30 +1253,59 @@ void NanoAODAnalyzerrdframe::matchGenReco() {
 
     _rlm = _rlm.Define("drmax1", "float(0.15)")
                .Define("drmax2", "float(0.4)")
-               .Define("Muon_matched", ::dRmatching_binary,{"GenPart_LFVmuon_idx","drmax1","GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","Muon_pt","Muon_eta","Muon_phi","Muon_mass"})
-               .Define("Tau_matched",::dRmatching_binary,{"GenPart_LFVtau_idx","drmax2", "GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","Tau_pt","Tau_eta","Tau_phi","Tau_mass"})
-               .Define("Jet_LFVup_matched",::dRmatching_binary,{"GenPart_LFVup_idx","drmax2","GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","Jet_pt","Jet_eta","Jet_phi","Jet_mass"})
-               .Define("Jet_SMb_matched",::dRmatching_binary,{"GenPart_SMb_idx","drmax2","GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","Jet_pt","Jet_eta","Jet_phi","Jet_mass"})
-               .Define("Jet_SMW1_matched",::dRmatching_binary,{"GenPart_SMW1_idx","drmax2","GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","Jet_pt","Jet_eta","Jet_phi","Jet_mass"})
-               .Define("Jet_SMW2_matched",::dRmatching_binary,{"GenPart_SMW2_idx","drmax2", "GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","Jet_pt","Jet_eta","Jet_phi","Jet_mass"})
-               .Define("Sel_muon_matched","Muon_matched[muoncuts]")
-               .Define("Sel_tau_matched","Tau_matched[seltaucuts]")
-               .Define("Sel2_LFVupjet_matched","Jet_LFVup_matched[jetcuts][muonjetoverlap][taujetoverlap]")
-               .Define("Sel2_SMbjet_matched","Jet_SMb_matched[jetcuts][muonjetoverlap][taujetoverlap]")
-               .Define("Sel2_SMW1jet_matched","Jet_SMW1_matched[jetcuts][muonjetoverlap][taujetoverlap]")
-               .Define("Sel2_SMW2jet_matched","Jet_SMW2_matched[jetcuts][muonjetoverlap][taujetoverlap]")
-               .Define("Sel_muonmatched_idx","ArgMax(Sel_muon_matched)")
-               .Define("Sel_taumatched_idx","ArgMax(Sel_tau_matched)")
-               .Define("Sel2_LFVupjet_matched_idx","ArgMax(Sel2_LFVupjet_matched)")
-               .Define("Sel2_SMbjet_matched_idx","ArgMax(Sel2_SMbjet_matched)")
-               .Define("Sel2_SMW1jet_matched_idx","ArgMax(Sel2_SMW1jet_matched)")
-               .Define("Sel2_SMW2jet_matched_idx","ArgMax(Sel2_SMW2jet_matched)")
-               .Define("nmuonmatched", "Sum(Muon_matched)")
-               .Define("ntaumatched", "Sum(Tau_matched)")
-               .Define("nJet_LFVup_matched", "Sum(Jet_LFVup_matched)")
+               .Define("GenJet_SMb_matched",::dRmatching_binary,{"GenPart_SMb_idx","drmax2","GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","GenJet_pt","GenJet_eta","GenJet_phi","GenJet_mass"})
+               .Define("GenJet_SMW1_matched",::dRmatching_binary,{"GenPart_SMW1_idx","drmax2","GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","GenJet_pt","GenJet_eta","GenJet_phi","GenJet_mass"})
+               .Define("GenJet_SMW2_matched",::dRmatching_binary,{"GenPart_SMW2_idx","drmax2", "GenPart_pt","GenPart_eta","GenPart_phi","GenPart_mass","GenJet_pt","GenJet_eta","GenJet_phi","GenJet_mass"})
+               .Define("bin1", "int (1)")
+               .Define("GenJet_SMb_idx", ::Find_element, {"GenJet_SMb_matched","bin1"})
+               .Define("GenJet_SMW1_idx", ::Find_element, {"GenJet_SMW1_matched","bin1"})
+               .Define("GenJet_SMW2_idx", ::Find_element, {"GenJet_SMW2_matched","bin1"})
+               .Define("Jet_SMb_matched",::dRmatching_binary,{"GenJet_SMb_idx","drmax2","GenJet_pt","GenJet_eta","GenJet_phi","GenJet_mass","Jet_pt","Jet_eta","Jet_phi","Jet_mass"})
+               .Define("Jet_SMW1_matched",::dRmatching_binary,{"GenJet_SMW1_idx","drmax2","GenJet_pt","GenJet_eta","GenJet_phi","GenJet_mass","Jet_pt","Jet_eta","Jet_phi","Jet_mass"})
+               .Define("Jet_SMW2_matched",::dRmatching_binary,{"GenJet_SMW2_idx","drmax2", "GenJet_pt","GenJet_eta","GenJet_phi","GenJet_mass","Jet_pt","Jet_eta","Jet_phi","Jet_mass"})
+               .Define("SMb_matched_idx", ::Find_element, {"Jet_SMb_matched", "bin1"})
+               .Define("SMW1_matched_idx", ::Find_element, {"Jet_SMW1_matched", "bin1"})
+               .Define("SMW2_matched_idx", ::Find_element, {"Jet_SMW2_matched", "bin1"})
                .Define("nJet_SMb_matched", "Sum(Jet_SMb_matched)")
                .Define("nJet_SMW1_matched", "Sum(Jet_SMW1_matched)")
                .Define("nJet_SMW2_matched", "Sum(Jet_SMW2_matched)");
+
+    _rlm = _rlm.Define("nGenJet_SMb_matched", "Sum(GenJet_SMb_matched)")
+               .Define("nGenJet_SMW1_matched", "Sum(GenJet_SMW1_matched)")
+               .Define("nGenJet_SMW2_matched", "Sum(GenJet_SMW2_matched)");
+
+    _rlm = _rlm.Define("GenJet_SMbmatched_pt","GenJet_pt[GenJet_SMb_matched]")
+               .Define("GenJet_SMbmatched_eta","GenJet_eta[GenJet_SMb_matched]")
+               .Define("GenJet_SMbmatched_phi","GenJet_phi[GenJet_SMb_matched]")
+               .Define("GenJet_SMbmatched_mass","GenJet_mass[GenJet_SMb_matched]")
+               .Define("GenJet_SMbmatched_4vecs", ::gen4vec, {"GenJet_SMbmatched_pt","GenJet_SMbmatched_eta","GenJet_SMbmatched_phi","GenJet_SMbmatched_mass"})
+               .Define("GenJet_SMW1matched_pt","GenJet_pt[GenJet_SMW1_matched]")
+               .Define("GenJet_SMW1matched_eta","GenJet_eta[GenJet_SMW1_matched]")
+               .Define("GenJet_SMW1matched_phi","GenJet_phi[GenJet_SMW1_matched]")
+               .Define("GenJet_SMW1matched_mass","GenJet_mass[GenJet_SMW1_matched]")
+               .Define("GenJet_SMW1matched_4vecs", ::gen4vec, {"GenJet_SMW1matched_pt","GenJet_SMW1matched_eta","GenJet_SMW1matched_phi","GenJet_SMW1matched_mass"})
+               .Define("GenJet_SMW2matched_pt","GenJet_pt[GenJet_SMW2_matched]")
+               .Define("GenJet_SMW2matched_eta","GenJet_eta[GenJet_SMW2_matched]")
+               .Define("GenJet_SMW2matched_phi","GenJet_phi[GenJet_SMW2_matched]")
+               .Define("GenJet_SMW2matched_mass","GenJet_mass[GenJet_SMW2_matched]")
+               .Define("GenJet_SMW2matched_4vecs",::gen4vec, {"GenJet_SMW2matched_pt","GenJet_SMW2matched_eta","GenJet_SMW2matched_phi","GenJet_SMW2matched_mass"});
+
+    _rlm = _rlm.Define("Jet_SMbmatched_pt","Jet_pt[Jet_SMb_matched]")
+               .Define("Jet_SMbmatched_eta","Jet_eta[Jet_SMb_matched]")
+               .Define("Jet_SMbmatched_phi","Jet_phi[Jet_SMb_matched]")
+               .Define("Jet_SMbmatched_mass","Jet_mass[Jet_SMb_matched]")
+               .Define("Jet_SMbmatched_4vecs", ::gen4vec, {"Jet_SMbmatched_pt","Jet_SMbmatched_eta","Jet_SMbmatched_phi","Jet_SMbmatched_mass"})
+               .Define("Jet_SMW1matched_pt","Jet_pt[Jet_SMW1_matched]")
+               .Define("Jet_SMW1matched_eta","Jet_eta[Jet_SMW1_matched]")
+               .Define("Jet_SMW1matched_phi","Jet_phi[Jet_SMW1_matched]")
+               .Define("Jet_SMW1matched_mass","Jet_mass[Jet_SMW1_matched]")
+               .Define("Jet_SMW1matched_4vecs", ::gen4vec, {"Jet_SMW1matched_pt","Jet_SMW1matched_eta","Jet_SMW1matched_phi","Jet_SMW1matched_mass"})
+               .Define("Jet_SMW2matched_pt","Jet_pt[Jet_SMW2_matched]")
+               .Define("Jet_SMW2matched_eta","Jet_eta[Jet_SMW2_matched]")
+               .Define("Jet_SMW2matched_phi","Jet_phi[Jet_SMW2_matched]")
+               .Define("Jet_SMW2matched_mass","Jet_mass[Jet_SMW2_matched]")
+               .Define("Jet_SMW2matched_4vecs",::gen4vec, {"Jet_SMW2matched_pt","Jet_SMW2matched_eta","Jet_SMW2matched_phi","Jet_SMW2matched_mass"});
+    cout << "match Gen Reco ended" << endl;
 }
 
 void NanoAODAnalyzerrdframe::selectFatJets() {

--- a/nanoaodframe/src/utility.cpp
+++ b/nanoaodframe/src/utility.cpp
@@ -118,25 +118,24 @@ ints good_idx(ints good)
         return out;
 }
 
-
 floats top_reconstruction_STLFV(FourVectorVec &jets, FourVectorVec &bjets, FourVectorVec &muons, FourVectorVec &taus){
-        
+
         floats out;
         float SMW_mass, SMtop_mass;
         float X_SMW, X_SMtop;
         float X_min=9999999999, X_min_SMW_mass=-1, X_min_SMtop_mass=-1;
         float X_min_SMW=999999999, X_min_SMtop=999999999;
         float wj1_idx=-1, wj2_idx=-1;
-        const float MT = 165.2;
-        const float MW = 80.8;
-        const float WT = 21.3;
-        const float WW = 11.71;	
+        const float MT = 173.95;
+        const float MW = 84.19;
+        const float WT = 17.07;
+        const float WW = 9.91;	
         
         // Jets from W-1
-        for(int j1 = 0; j1<int(jets.size()); j1++){
+        for(int j1 = 0; j1<int(jets.size()-1); j1++){
             if(jets[j1].Pt() == bjets[0].Pt()) continue;
             // Jets from W-2
-            for(int j2 = 0; j2<int(jets.size()); j2++){
+            for(int j2 = j1+1; j2<int(jets.size()); j2++){
                 if(jets[j2].Pt() == jets[j1].Pt() || jets[j2].Pt() == bjets[0].Pt()) continue;
                 SMW_mass = (jets[j1]+jets[j2]).M();
                 X_SMW = std::pow((MW-SMW_mass)/WW,2);
@@ -337,11 +336,30 @@ floats sort_discriminant( floats discr, floats obj ){
 }
 
 ints find_element(ints vec, int a){
+    std::cout << "find element a = " << a << ": ";
+    if (a == 999) {
+        a = 1;
+    }
     ints idx;
     for(int i = 0; i < int(vec.size()); i++){
-        if( vec[i] == a ) idx.emplace_back(i);
+        if( vec[i] == a ) {
+            idx.emplace_back(i);
+            std::cout << i << " ";
+        }
+    }
+    if (idx.size() == 0) {
+        idx.emplace_back(-1);
+        std::cout << -1;
     }
     return idx;
+}
+int Find_element(ints vec, int a){
+    for(int i = 0; i < int(vec.size()); i++){
+        if( vec[i] == a ) {
+            return i;
+        }
+    }
+    return -1;
 }
 
 ints find_element_binary( ints vec, int a){
@@ -400,13 +418,16 @@ int lastgenpart_idx(int target_i, ints GenPart_pdgId, ints GenPart_genPartIdxMot
 
 ints FinalGenPart_idx( ints GenPart_pdgId, ints GenPart_genPartIdxMother ){
     ints out;
-    int LFVtop_idx = -1, SMtop_idx=-1;
+    int LFVtop_idx = -1, SMtop_idx=-1, SMhadtop_idx=-1;
     int up_idx = -1, muon_idx = -1, tau_idx = -1;
     int b_idx = -1, W_idx = -1;
     int Wq1_idx=-1, Wq2_idx=-1;
+    int W1_idx=-1, W2_idx=-1;
     ints Wds_i;
     ints LastTop_idx = LastGenPart_idx(6, GenPart_pdgId, GenPart_genPartIdxMother);
+    std::cout << "FinalGenPart_idx: ";
     for( int i : LastTop_idx ){
+        std::cout << i << ", ";
         ints ds_idx = find_element(GenPart_genPartIdxMother, i);
         for( int d_idx : ds_idx ){
             int d_id = GenPart_pdgId[d_idx];
@@ -416,23 +437,39 @@ ints FinalGenPart_idx( ints GenPart_pdgId, ints GenPart_genPartIdxMother ){
             }
             if(abs(d_id)==13){
                 muon_idx = lastgenpart_idx(d_idx, GenPart_pdgId, GenPart_genPartIdxMother);
+                LFVtop_idx=i;
             }
             if(abs(d_id)==15){
                 tau_idx = lastgenpart_idx(d_idx, GenPart_pdgId, GenPart_genPartIdxMother);
-            }
-            if(abs(d_id)==5){
-                b_idx = lastgenpart_idx(d_idx, GenPart_pdgId, GenPart_genPartIdxMother);
-                SMtop_idx=i;
+                LFVtop_idx=i;
             }
             if(abs(d_id)==24){
                 W_idx = lastgenpart_idx(d_idx, GenPart_pdgId, GenPart_genPartIdxMother);
                 Wds_i = find_element(GenPart_genPartIdxMother, W_idx);
                 if( Wds_i.size() !=2 ) break;
-                Wq1_idx = lastgenpart_idx(Wds_i[0], GenPart_pdgId, GenPart_genPartIdxMother);
-                Wq2_idx = lastgenpart_idx(Wds_i[1], GenPart_pdgId, GenPart_genPartIdxMother);
+                W1_idx = lastgenpart_idx(Wds_i[0], GenPart_pdgId, GenPart_genPartIdxMother);
+                W2_idx = lastgenpart_idx(Wds_i[1], GenPart_pdgId, GenPart_genPartIdxMother);
+                if ( abs(GenPart_pdgId[W1_idx]) < 6  && abs(GenPart_pdgId[W2_idx]) < 6 ) {
+                    Wq1_idx = W1_idx;
+                    Wq2_idx = W2_idx;
+                    SMhadtop_idx = i;
+                    std::cout<<"hadtop: " << W1_idx << " " << W2_idx << std::endl;
+                } else{
+                    std::cout<<"can not found hadtop: " << W1_idx << " " << W2_idx << std::endl;
+                }
+            }
+        }
+        if (i != SMhadtop_idx) continue;
+        for ( int d_idx : ds_idx ){
+            int d_id = GenPart_pdgId[d_idx];
+            if(abs(d_id)==5){
+                b_idx = lastgenpart_idx(d_idx, GenPart_pdgId, GenPart_genPartIdxMother);
+                SMtop_idx=i;
             }
         }
     }
+    if ( b_idx < 0 ) std::cout << "b is not found!" << std::endl;
+    std::cout << " " << std::endl;
     out.emplace_back(up_idx);
     out.emplace_back(muon_idx);
     out.emplace_back(tau_idx);
@@ -457,7 +494,8 @@ ints dRmatching_binary( int origin_i,float maxdR,  floats origin_pt, floats orig
 
     for(int i=0; i<int(target.size()); i++){
         tempdR = ROOT::Math::VectorUtil::DeltaR(origin[origin_i],target[i]); 
-        if( tempdR < dR ){
+        //if( tempdR < dR ){
+        if( tempdR < dR && abs(origin_pt[origin_i]-target_pt[i])<20 ){
             target_i = i;
             dR = tempdR;
         }
@@ -469,6 +507,11 @@ ints dRmatching_binary( int origin_i,float maxdR,  floats origin_pt, floats orig
     return target_binary;
 }
 
+float SumMass2( FourVectorVec object1, FourVectorVec object2){
+    FourVector SumV = object1[0] + object2[0];
+    float SumM = SumV.M();
+    return SumM;
+}
 
 float SumMass( FourVectorVec object1, FourVectorVec object2, FourVectorVec object3){
     FourVector SumV = object1[0] + object2[0] + object3[0];

--- a/nanoaodframe/src/utility.h
+++ b/nanoaodframe/src/utility.h
@@ -92,6 +92,8 @@ floats sort_discriminant( floats discr, floats obj );
 
 ints find_element(ints vec, int a);
 
+int Find_element(ints vec, int a);
+
 ints find_element_binary( ints vec, int a);
 
 ints LastGenPart_idx( int target_id, ints GenPart_pdgId, ints GenPart_genPartIdxMother);
@@ -101,6 +103,8 @@ int lastgenpart_idx(int target_i, ints GenPart_pdgId, ints GenPart_genPartIdxMot
 ints FinalGenPart_idx( ints GenPart_pdgId, ints GenPart_genPartIdxMother);
 
 ints dRmatching_binary( int origin_i,float maxdR,  floats origin_pt, floats origin_eta, floats origin_phi, floats origin_mass, floats target_pt, floats target_eta, floats target_phi, floats target_mass);
+
+float SumMass2( FourVectorVec object1, FourVectorVec object2);
 
 float SumMass( FourVectorVec object1, FourVectorVec object2, FourVectorVec object3);
 


### PR DESCRIPTION
1. Update top and W boson mass and width in the chi2 top reconstruction method
2. Update metchGenReco function for Top and W mass reconstruction in gen-level
    If you want to fit gen-level top and W mass,
    1) Run matchGenReco at NanoAODAnalyseedframe::setupAnalysis()
    2) Book some variables and histograms at TopLFVAnalyzer (for this, you should define some other cuts at defineCuts())
    3) Run fitting scripts at scripts/massfit.py